### PR TITLE
Addressing issues with docs and docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETARCH=amd64
 # ============================================
 # Stage 1: Configure APT repository
 # ============================================
-FROM ubuntu:24.04 as downloader
+FROM ubuntu:24.04 AS downloader
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND
@@ -35,7 +35,7 @@ RUN mkdir -p /etc/apt/keyrings && \
 # ============================================
 # Stage 2: Install OpenSPP package
 # ============================================
-FROM ubuntu:24.04 as installer
+FROM ubuntu:24.04 AS installer
 
 ARG DEBIAN_FRONTEND
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,76 +2,87 @@
 # ABOUTME: Multi-stage build with security hardening and multi-arch support
 
 # Build arguments for version control
-ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETARCH=amd64
+ARG BASE_IMAGE=ubuntu:24.04
 
 # ============================================
-# Stage 1: Configure APT repository
+# Stage 1: Install OpenSPP package
 # ============================================
-FROM ubuntu:24.04 AS downloader
+FROM ${BASE_IMAGE} AS openspp_installer
 
-ARG TARGETARCH
-ARG DEBIAN_FRONTEND
-
-# Install minimal tools for repository setup
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-
-# Configure OpenSPP daily APT repository
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
-    gpg --dearmor -o /etc/apt/keyrings/openspp.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
-    /etc/apt/sources.list.d/openspp.list && \
-    apt-get update && \
-    apt-cache show openspp-17-daily
-
-# ============================================
-# Stage 2: Install OpenSPP package
-# ============================================
-FROM ubuntu:24.04 AS installer
-
-ARG DEBIAN_FRONTEND
-ARG TARGETARCH
-
-# Copy repository configuration from downloader stage
-COPY --from=downloader /etc/apt/keyrings/openspp.gpg /etc/apt/keyrings/
-COPY --from=downloader /etc/apt/sources.list.d/openspp.list /etc/apt/sources.list.d/
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Install ca-certificates first, then OpenSPP package from APT repository
 # Create a fake systemctl to handle postinst scripts in Docker
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
+# Configure OpenSPP daily APT repository
+RUN mkdir -p /etc/apt/keyrings \
     && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+    && curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
+      gpg --dearmor -o /etc/apt/keyrings/openspp.gpg \
+    && gpg --show-keys /etc/apt/keyrings/openspp.gpg | grep "BE1468830EFDA9887F0BBD077A335D5FB4C1A749" \
+    && echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
+      /etc/apt/sources.list.d/openspp.list \
     && echo '#!/bin/sh' > /usr/bin/systemctl \
     && echo 'exit 0' >> /usr/bin/systemctl \
     && chmod +x /usr/bin/systemctl \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
-        openspp-17-daily \
+       openspp-17-daily \
     && rm -f /usr/bin/systemctl \
     && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# ============================================
+# Stage 2: Install wkhtmltopdf
+# ============================================
+FROM ${BASE_IMAGE} AS wkhtmltopdf_installer
+
+ARG BASE_IMAGE=ubuntu:24.04
+ARG TARGETARCH=amd64
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Install ca-certificates first, then OpenSPP package from APT repository
+# Create a fake systemctl to handle postinst scripts in Docker
+# Configure OpenSPP daily APT repository
+WORKDIR /tmp
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && case "${BASE_IMAGE}" in \
+    *"debian"* | *"bookworm"*) WKHTMLTOPDF_DISTRIB=bookworm && WKHTMLTOPDF_SHA=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d  ;; \
+    *"ubuntu"*)  WKHTMLTOPDF_DISTRIB=jammy && WKHTMLTOPDF_SHA=4f723b2691ad8638a9df960e0421d346d7315083e3583a334f33362280ddba15  ;; \
+    esac \
+    && curl -o wkhtmltox.deb -sSL "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.${WKHTMLTOPDF_DISTRIB}_${TARGETARCH}.deb" \
+    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha256sum -c - \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
 # Stage 3: Final production image
 # ============================================
-FROM ubuntu:24.04
+FROM ${BASE_IMAGE}
 
-ARG DEBIAN_FRONTEND
-ARG BUILD_DATE
-ARG VCS_REF
+ARG BASE_IMAGE=ubuntu:24.04
+ARG BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GID=1001
+ARG OPENSPP_LEFT_TO_RIGHT_LANGUAGE_SUPPORT=false
+ARG OPENSPP_VERSION=17.0-daily
+ARG PYTHONUNBUFFERED=1
+ARG PYTHONDONTWRITEBYTECODE=1
+ARG UID=1001
+ARG VCS_REF="unspecified"
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # OCI Image Specification labels
 LABEL org.opencontainers.image.title="OpenSPP" \
       org.opencontainers.image.description="OpenSPP Social Protection Platform based on Odoo 17" \
-      org.opencontainers.image.version="17.0-daily" \
+      org.opencontainers.image.version="${OPENSPP_VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.authors="OpenSPP Team <support@openspp.org>" \
@@ -80,69 +91,57 @@ LABEL org.opencontainers.image.title="OpenSPP" \
       org.opencontainers.image.source="https://github.com/openspp/openspp-packaging-docker" \
       org.opencontainers.image.vendor="OpenSPP" \
       org.opencontainers.image.licenses="LGPL-3.0" \
-      org.opencontainers.image.base.name="ubuntu:24.04"
+      org.opencontainers.image.base.name="${BASE_IMAGE}"
+
+# Set environment variables
+# Generate locale C.UTF-8 for postgres and general locale data
+# We need to set the DEBIAN_FRONTEND variable to prevent tzdata from asking us questions
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    UID=${UID} \
+    GID=${GID} \
+    PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    ODOO_RC=/etc/openspp/odoo.conf \
+    PATH="/opt/openspp/venv/bin:$PATH" \
+    HOME="/var/lib/openspp"
+
+COPY --from=wkhtmltopdf_installer /tmp/wkhtmltox.deb /tmp/wkhtmltox.deb
 
 # Install only runtime dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+# Create openspp user and group with consistent IDs
+# Create necessary directories with proper permissions
+RUN apt-get update \
+    && DEBIAN_FRONTEND=${DEBIAN_FRONTEND} apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        fontconfig \
-        fonts-liberation \
-        fonts-noto \
-        fonts-noto-cjk \
-        fonts-noto-color-emoji \
-        gnupg \
-        gosu \
-        libjs-jquery \
-        libpq5 \
-        libssl3 \
         locales \
-        node-less \
-        npm \
         postgresql-client \
         python3 \
         python3-venv \
-        python3-magic \
-        python3-num2words \
-        python3-odf \
-        python3-pdfminer \
-        python3-phonenumbers \
-        python3-pyldap \
-        python3-qrcode \
-        python3-renderpm \
-        python3-slugify \
-        python3-vobject \
-        python3-watchdog \
-        python3-xlrd \
-        python3-xlwt \
         tzdata \
+        /tmp/wkhtmltox.deb \
+    && if [ "${OPENSPP_LEFT_TO_RIGHT_LANGUAGE_SUPPORT}" = "true" ]; then \
+        apt-get install -y --no-install-recommends \
+            node-less \
+            npm \
+        && npm install -g rtlcss \
+        && apt-get remove -y npm ; \
+    fi \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
-    && npm install -g rtlcss \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Set locale environment
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
-
-# Create openspp user and group with consistent IDs
-# Check if GID 1000 exists, if so use a different one (9999)
-RUN (groupadd -r -g 1000 openspp 2>/dev/null || groupadd -r openspp) && \
-    useradd -r -g openspp \
+    && apt-get autopurge -yqq \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /tmp/wkhtmltox.deb \
+    && bash -c "if ! getent group ${GID}; then groupadd -r -g ${GID} openspp; fi" \
+    && useradd -l -u ${UID} -r -g ${GID} \
         -d /var/lib/openspp \
         -s /bin/bash \
-        -m openspp
-
-# Copy OpenSPP installation from installer stage with correct ownership
-COPY --chown=openspp:openspp --from=installer /opt/openspp /opt/openspp
-COPY --from=installer /usr/bin/openspp-* /usr/bin/
-COPY --chown=openspp:openspp --from=installer /etc/openspp /etc/openspp
-
-# Create necessary directories with proper permissions
-RUN mkdir -p \
+        -m openspp \
+    && mkdir -p \
         /var/lib/openspp \
         /var/log/openspp \
         /mnt/extra-addons \
@@ -153,17 +152,15 @@ RUN mkdir -p \
         /mnt/extra-addons \
         /opt/openspp/data
 
+# Copy OpenSPP installation from installer stage with correct ownership
+COPY --chown=openspp:openspp --from=openspp_installer /opt/openspp /opt/openspp
+COPY --from=openspp_installer /usr/bin/openspp-* /usr/bin/
+COPY --chown=openspp:openspp --from=openspp_installer /etc/openspp /etc/openspp
+
 # Copy configuration and entrypoint scripts
 COPY --chown=openspp:openspp config/odoo.conf /etc/openspp/odoo.conf
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
 COPY --chmod=755 wait-for-psql.py /usr/local/bin/
-
-# Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    ODOO_RC=/etc/openspp/odoo.conf \
-    PATH="/opt/openspp/venv/bin:$PATH" \
-    HOME="/var/lib/openspp"
 
 # Create volume mount points
 VOLUME ["/var/lib/openspp", "/mnt/extra-addons"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -2,53 +2,29 @@
 # ABOUTME: Optimized for size while maintaining compatibility
 
 # Build arguments for version control
-ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETARCH=amd64
+ARG BASE_IMAGE=debian:bookworm-slim
 
 # ============================================
-# Stage 1: Configure APT repository
+# Stage 1: Install OpenSPP package
 # ============================================
-FROM debian:bookworm-slim as downloader
+# FROM debian:bookworm-slim AS installer
+FROM debian:bookworm-slim AS installer
 
-ARG TARGETARCH
-ARG DEBIAN_FRONTEND
-
-# Install minimal tools for repository setup
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-
-# Configure OpenSPP daily APT repository
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
-    gpg --dearmor -o /etc/apt/keyrings/openspp.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
-    /etc/apt/sources.list.d/openspp.list && \
-    apt-get update && \
-    apt-cache show openspp-17-daily
-
-# ============================================
-# Stage 2: Install OpenSPP package
-# ============================================
-FROM debian:bookworm-slim as installer
-
-ARG DEBIAN_FRONTEND
-ARG TARGETARCH
-
-# Copy repository configuration from downloader stage
-COPY --from=downloader /etc/apt/keyrings/openspp.gpg /etc/apt/keyrings/
-COPY --from=downloader /etc/apt/sources.list.d/openspp.list /etc/apt/sources.list.d/
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Install ca-certificates first, then OpenSPP package from APT repository
 # Create a fake systemctl to handle postinst scripts in Docker
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
+        gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
+    gpg --dearmor -o /etc/apt/keyrings/openspp.gpg \
+    && gpg --show-keys /etc/apt/keyrings/openspp.gpg | grep "BE1468830EFDA9887F0BBD077A335D5FB4C1A749" \
+    && echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
+    /etc/apt/sources.list.d/openspp.list \
     && apt-get update \
     && echo '#!/bin/sh' > /usr/bin/systemctl \
     && echo 'exit 0' >> /usr/bin/systemctl \
@@ -60,18 +36,51 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
+# Stage 2: Install wkhtmltopdf
+# ============================================
+FROM ${BASE_IMAGE} AS wkhtmltopdf_installer
+
+ARG BASE_IMAGE=debian:bookworm-slim
+ARG TARGETARCH=amd64
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Install ca-certificates first, then OpenSPP package from APT repository
+# Create a fake systemctl to handle postinst scripts in Docker
+# Configure OpenSPP daily APT repository
+WORKDIR /tmp
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && WKHTMLTOPDF_DISTRIB=bookworm \
+    && WKHTMLTOPDF_SHA=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d \
+    && curl -o wkhtmltox.deb -sSL "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.${WKHTMLTOPDF_DISTRIB}_${TARGETARCH}.deb" \
+    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha256sum -c - \
+    && rm -rf /var/lib/apt/lists/*
+
+# ============================================
 # Stage 3: Final slim production image
 # ============================================
+# FROM debian:bookworm-slim
 FROM debian:bookworm-slim
 
-ARG DEBIAN_FRONTEND
-ARG BUILD_DATE
-ARG VCS_REF
+ARG BASE_IMAGE=debian:bookworm-slim
+ARG BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GID=1001
+ARG OPENSPP_VERSION=17.0-daily
+ARG PYTHONUNBUFFERED=1
+ARG PYTHONDONTWRITEBYTECODE=1
+ARG UID=1001
+ARG VCS_REF="unspecified"
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # OCI Image Specification labels
 LABEL org.opencontainers.image.title="OpenSPP Slim" \
       org.opencontainers.image.description="Lightweight OpenSPP Social Protection Platform based on Debian slim" \
-      org.opencontainers.image.version="17.0-daily" \
+      org.opencontainers.image.version="${OPENSPP_VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.authors="OpenSPP Team <support@openspp.org>" \
@@ -80,53 +89,50 @@ LABEL org.opencontainers.image.title="OpenSPP Slim" \
       org.opencontainers.image.source="https://github.com/openspp/openspp-packaging-docker" \
       org.opencontainers.image.vendor="OpenSPP" \
       org.opencontainers.image.licenses="LGPL-3.0" \
-      org.opencontainers.image.base.name="debian:bookworm-slim"
+      org.opencontainers.image.base.name="${BASE_IMAGE}"
+
+# Set environment variables
+# Generate locale C.UTF-8 for postgres and general locale data
+# We need to set the DEBIAN_FRONTEND variable to prevent tzdata from asking us questions
+ENV UID=${UID} \
+    GID=${GID} \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    ODOO_RC=/etc/openspp/odoo.conf \
+    PATH="/opt/openspp/venv/bin:$PATH" \
+    HOME="/var/lib/openspp"
+
+COPY --from=wkhtmltopdf_installer /tmp/wkhtmltox.deb /tmp/wkhtmltox.deb
 
 # Install only essential runtime dependencies
 # Keeping this minimal for the slim image
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=${DEBIAN_FRONTEND} apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        fontconfig \
-        fonts-liberation2 \
-        fonts-noto-core \
-        gosu \
-        libpq5 \
-        libssl3 \
         locales \
         postgresql-client \
         python3 \
         python3-venv \
         tzdata \
+        /tmp/wkhtmltox.deb \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/share/doc/* \
     && rm -rf /usr/share/man/* \
-    && rm -rf /usr/share/info/*
-
-# Set locale environment
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
-
-# Create openspp user and group with consistent IDs
-# Check if GID 1000 exists, if so use a different one (9999)
-RUN (groupadd -r -g 1000 openspp 2>/dev/null || groupadd -r openspp) && \
-    useradd -r -g openspp \
+    && rm -rf /usr/share/info/* \
+    && rm -f /tmp/wkhtmltox.deb \
+    && bash -c "if ! getent group ${GID}; then groupadd -r -g ${GID} openspp; fi" \
+    && useradd -l -u ${UID} -r -g ${GID} \
         -d /var/lib/openspp \
         -s /bin/bash \
-        -m openspp
-
-# Copy OpenSPP installation from installer stage with correct ownership
-COPY --chown=openspp:openspp --from=installer /opt/openspp /opt/openspp
-COPY --from=installer /usr/bin/openspp-* /usr/bin/
-COPY --chown=openspp:openspp --from=installer /etc/openspp /etc/openspp
-
-# Create necessary directories with proper permissions
-RUN mkdir -p \
+        -m openspp \
+    && mkdir -p \
         /var/lib/openspp \
         /var/log/openspp \
         /mnt/extra-addons \
@@ -137,17 +143,15 @@ RUN mkdir -p \
         /mnt/extra-addons \
         /opt/openspp/data
 
+# Copy OpenSPP installation from installer stage with correct ownership
+COPY --chown=openspp:openspp --from=installer /opt/openspp /opt/openspp
+COPY --from=installer /usr/bin/openspp-* /usr/bin/
+COPY --chown=openspp:openspp --from=installer /etc/openspp /etc/openspp
+
 # Copy configuration and entrypoint scripts
 COPY --chown=openspp:openspp config/odoo.conf /etc/openspp/odoo.conf
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
 COPY --chmod=755 wait-for-psql.py /usr/local/bin/
-
-# Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    ODOO_RC=/etc/openspp/odoo.conf \
-    PATH="/opt/openspp/venv/bin:$PATH" \
-    HOME="/var/lib/openspp"
 
 # Create volume mount points
 VOLUME ["/var/lib/openspp", "/mnt/extra-addons"]

--- a/GITHUB_ACTIONS_SETUP.md
+++ b/GITHUB_ACTIONS_SETUP.md
@@ -9,10 +9,12 @@ This repository uses GitHub Actions for CI/CD to build and push OpenSPP Docker i
 Configure the following secrets in your GitHub repository settings:
 
 ### Registry Authentication
+
 - `NEXUS_USERNAME`: Nexus registry username (e.g., `admin`)
 - `NEXUS_PASSWORD`: Nexus registry password
 
 ### Optional Notifications
+
 - `SLACK_WEBHOOK`: Slack webhook URL for build notifications (optional)
 
 ### Setting Secrets
@@ -31,12 +33,14 @@ Configure the following secrets in your GitHub repository settings:
 ### 1. Docker Build and Push (`docker-build.yml`)
 
 **Triggers:**
+
 - Push to main, master, develop, or release/* branches
 - Pull requests to main, master, or develop
 - Git tags (v*, semantic versioning)
 - Manual workflow dispatch
 
 **Actions:**
+
 - Builds Ubuntu 24.04 and Debian slim Docker images
 - **Platform:** linux/amd64 only (no ARM support)
 - Pushes to Nexus registry (`docker-push.acn.fr`)
@@ -45,6 +49,7 @@ Configure the following secrets in your GitHub repository settings:
 - Updates Kubernetes manifests on tag releases
 
 **Image Tags:**
+
 - `latest` / `latest-slim` - Latest from main branch
 - `daily` / `daily-slim` - Daily builds from main branch
 - `v1.0.0` / `v1.0.0-slim` - Version tags
@@ -54,12 +59,14 @@ Configure the following secrets in your GitHub repository settings:
 ### 2. Security Scan (`security-scan.yml`)
 
 **Triggers:**
+
 - Push to main branches
 - Pull requests
 - Daily at 2 AM UTC
 - Manual workflow dispatch
 
 **Actions:**
+
 - Trivy vulnerability scanning
 - Hadolint Dockerfile linting
 - OWASP dependency checking
@@ -78,6 +85,7 @@ Configure the following secrets in your GitHub repository settings:
 ### Automatic Builds
 
 Images are automatically built and pushed when:
+
 - Pushing to main/master/develop branches
 - Creating a new release tag
 - Changes are tested (but not pushed) on pull requests
@@ -85,12 +93,14 @@ Images are automatically built and pushed when:
 ## Registry Information
 
 ### Push Registry (Authentication Required)
-```
+
+``` text
 docker-push.acn.fr/openspp/openspp
 ```
 
 ### Public Registry (Anonymous Pull)
-```
+
+``` text
 docker.acn.fr/openspp/openspp
 ```
 
@@ -115,6 +125,7 @@ docker pull docker.acn.fr/openspp/openspp:v1.0.0-slim
 ## Build Status
 
 You can view build status in the **Actions** tab of your repository. Each workflow run shows:
+
 - Build logs
 - Test results
 - Security scan findings
@@ -125,8 +136,10 @@ You can view build status in the **Actions** tab of your repository. Each workfl
 ### Authentication Failures
 
 If builds fail with authentication errors:
+
 1. Verify `NEXUS_USERNAME` and `NEXUS_PASSWORD` secrets are set correctly
 2. Test credentials locally:
+
    ```bash
    docker login docker-push.acn.fr -u <username>
    ```
@@ -142,6 +155,7 @@ If builds fail with authentication errors:
 ### Security Scan Issues
 
 Security scans may find vulnerabilities. Check:
+
 1. **Security** tab for detailed reports
 2. Trivy results in workflow logs
 3. Consider updating base images or packages
@@ -152,13 +166,14 @@ Security scans may find vulnerabilities. Check:
 - **Base Images:**
   - Ubuntu: `ubuntu:24.04`
   - Slim: `debian:bookworm-slim`
-- **OpenSPP Source:** APT repository at https://builds.acn.fr/repository/apt-openspp-daily/
+- **OpenSPP Source:** APT repository at [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 
 ## Monitoring
 
 ### Build Notifications
 
 If `SLACK_WEBHOOK` is configured, you'll receive notifications for:
+
 - Successful builds
 - Failed builds
 - Security scan results
@@ -166,6 +181,7 @@ If `SLACK_WEBHOOK` is configured, you'll receive notifications for:
 ### GitHub Notifications
 
 Enable GitHub notifications to receive updates about:
+
 - Workflow failures
 - Security alerts
 - Pull request checks
@@ -181,6 +197,7 @@ Enable GitHub notifications to receive updates about:
 ## Support
 
 For issues with:
+
 - **GitHub Actions:** Check [GitHub Actions documentation](https://docs.github.com/actions)
 - **Docker builds:** Review Dockerfile and build logs
 - **Nexus registry:** Contact your Nexus administrator

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -2,14 +2,16 @@
 
 Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 
+``` text
 > **Note:** Configuration updated to install directly from OpenSPP APT repository instead of copying local deb files.
 > 
 > **Repository:** https://builds.acn.fr/repository/apt-openspp-daily/
 > **Package:** `openspp-17-daily`
+```
 
 ## Key Improvements Implemented
 
-### APT Repository Integration (Latest Update):
+### APT Repository Integration (Latest Update)
 
 1. **Direct APT Installation**
    - Removed dependency on local deb file copying
@@ -20,8 +22,8 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 2. **Repository Configuration**
    - Uses signed-by GPG key for secure APT repository
    - Supports both Ubuntu (noble) and Debian (bookworm) distributions
-   - Repository URL: https://builds.acn.fr/repository/apt-openspp-daily/
-   - GPG Key: https://builds.acn.fr/repository/apt-keys/openspp/public.key
+   - Repository URL: [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
+   - GPG Key: [https://builds.acn.fr/repository/apt-keys/openspp/public.key](https://builds.acn.fr/repository/apt-keys/openspp/public.key)
 
 3. **Benefits**
    - Always get latest daily build automatically
@@ -30,7 +32,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Simplified build process
    - Better integration with CI/CD pipelines
 
-### From Official Odoo Docker:
+### From Official Odoo Docker
 
 1. **Enhanced Python Dependencies**
    - Added Python packages for better compatibility: `python3-magic`, `python3-num2words`, `python3-odf`, `python3-pdfminer`, `python3-phonenumbers`, `python3-pyldap`, `python3-qrcode`, `python3-renderpm`, `python3-slugify`, `python3-vobject`, `python3-watchdog`, `python3-xlrd`, `python3-xlwt`
@@ -51,7 +53,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Respect config file values when set
    - More flexible configuration management
 
-### From OpenSPP Installation Guide:
+### From OpenSPP Installation Guide
 
 1. **Queue Job Configuration (CRITICAL)**
    - Set default workers to 2 (was 0)
@@ -75,7 +77,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Worker configuration for production vs development
    - Clear documentation about performance tuning
 
-## Files Updated:
+## Files Updated
 
 1. **Dockerfile**
    - Added Python dependencies and rtlcss
@@ -107,26 +109,29 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Production readiness checks
    - Database initialization helpers
 
-## Critical Requirements for OpenSPP:
+## Critical Requirements for OpenSPP
 
 ### Queue Job Module
+
 - **MUST** have workers > 0 (minimum 2 for production)
 - **MUST** include queue_job in server_wide_modules
 - **MUST** restart after installing queue_job module
 - Development mode (workers=0) disables async operations
 
-### Security in Production:
+### Security in Production
+
 - Set `list_db = False`
 - Use strong admin password
 - Enable `proxy_mode` when behind reverse proxy
 - Use Docker secrets for sensitive data
 
-### Performance:
+### Performance
+
 - Workers: 1 per CPU core (minimum 2)
 - Adjust memory limits based on available RAM
 - Use Redis for caching (separate container)
 
-## Testing Checklist:
+## Testing Checklist
 
 - [ ] Build standard image
 - [ ] Build slim image  
@@ -139,7 +144,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 - [ ] Check logs output
 - [ ] Validate production readiness
 
-## Next Steps:
+## Next Steps
 
 1. Run `make build-all` to build images (pulls from APT repository)
 2. Run `make run` to start development environment

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -2,12 +2,11 @@
 
 Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 
-``` text
-> **Note:** Configuration updated to install directly from OpenSPP APT repository instead of copying local deb files.
-> 
-> **Repository:** https://builds.acn.fr/repository/apt-openspp-daily/
+> [!NOTE]
+> Configuration updated to install directly from OpenSPP APT repository instead of copying local deb files.
+>
+> **Repository:** [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 > **Package:** `openspp-17-daily`
-```
 
 ## Key Improvements Implemented
 

--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,21 @@ COMPOSE_FILE ?= docker-compose.yml
 COMPOSE_PROD_FILE ?= docker-compose.prod.yml
 
 # Colors for output
-RED := \033[0;31m
-GREEN := \033[0;32m
+RED := \033[1;31m
+GREEN := \033[1;32m
 YELLOW := \033[1;33m
 NC := \033[0m # No Color
 
 help: ## Show this help message
-	@echo "$(GREEN)OpenSPP Docker Management$(NC)"
+	@echo -e "$(GREEN)OpenSPP Docker Management$(NC)"
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-15s$(NC) %s\n", $$1, $$2}'
 
 build: ## Build the standard Ubuntu-based image
-	@echo "$(GREEN)Building OpenSPP image (Ubuntu 24.04)...$(NC)"
-	@echo "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
+	@echo -e "$(GREEN)Building OpenSPP image (Ubuntu 24.04)...$(NC)"
+	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
 	docker build \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
@@ -39,8 +39,8 @@ build: ## Build the standard Ubuntu-based image
 		-f Dockerfile .
 
 build-slim: ## Build the lightweight Debian-based image
-	@echo "$(GREEN)Building OpenSPP slim image (Debian bookworm)...$(NC)"
-	@echo "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
+	@echo -e "$(GREEN)Building OpenSPP slim image (Debian bookworm)...$(NC)"
+	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
 	docker build \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
@@ -53,28 +53,28 @@ build-slim: ## Build the lightweight Debian-based image
 build-all: build build-slim ## Build both standard and slim images
 
 run: ## Start OpenSPP with docker-compose (development)
-	@echo "$(GREEN)Starting OpenSPP development environment...$(NC)"
+	@echo -e "$(GREEN)Starting OpenSPP development environment...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) up -d
-	@echo "$(GREEN)OpenSPP is starting at http://localhost:8069$(NC)"
-	@echo "$(YELLOW)Note: Workers are set to 2 for queue_job support$(NC)"
+	@echo -e "$(GREEN)OpenSPP is starting at http://localhost:8069$(NC)"
+	@echo -e "$(YELLOW)Note: Workers are set to 2 for queue_job support$(NC)"
 
 run-prod: ## Start OpenSPP with production configuration
-	@echo "$(GREEN)Starting OpenSPP production environment...$(NC)"
+	@echo -e "$(GREEN)Starting OpenSPP production environment...$(NC)"
 	docker-compose -f $(COMPOSE_PROD_FILE) up -d
-	@echo "$(GREEN)OpenSPP production is starting$(NC)"
+	@echo -e "$(GREEN)OpenSPP production is starting$(NC)"
 
 stop: ## Stop all OpenSPP containers
-	@echo "$(YELLOW)Stopping OpenSPP containers...$(NC)"
+	@echo -e "$(YELLOW)Stopping OpenSPP containers...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) down
 
 stop-prod: ## Stop production containers
-	@echo "$(YELLOW)Stopping OpenSPP production containers...$(NC)"
+	@echo -e "$(YELLOW)Stopping OpenSPP production containers...$(NC)"
 	docker-compose -f $(COMPOSE_PROD_FILE) down
 
 clean: ## Remove containers, volumes, and images
-	@echo "$(RED)Removing OpenSPP containers and volumes...$(NC)"
+	@echo -e "$(RED)Removing OpenSPP containers and volumes...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) down -v
-	@echo "$(RED)Removing OpenSPP images...$(NC)"
+	@echo -e "$(RED)Removing OpenSPP images...$(NC)"
 	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):latest || true
 	docker rmi $(IMAGE_NAME):$(IMAGE_TAG)-slim $(IMAGE_NAME):latest-slim || true
 
@@ -85,26 +85,26 @@ logs-all: ## View all container logs
 	docker-compose -f $(COMPOSE_FILE) logs -f
 
 shell: ## Open a shell in the OpenSPP container
-	@echo "$(GREEN)Opening shell in OpenSPP container...$(NC)"
+	@echo -e "$(GREEN)Opening shell in OpenSPP container...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec openspp /bin/bash
 
 shell-root: ## Open a root shell in the OpenSPP container
-	@echo "$(GREEN)Opening root shell in OpenSPP container...$(NC)"
+	@echo -e "$(GREEN)Opening root shell in OpenSPP container...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec -u root openspp /bin/bash
 
 db-shell: ## Open PostgreSQL shell
-	@echo "$(GREEN)Opening PostgreSQL shell...$(NC)"
+	@echo -e "$(GREEN)Opening PostgreSQL shell...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec db psql -U openspp openspp
 
 odoo-shell: ## Open Odoo Python shell
-	@echo "$(GREEN)Opening Odoo Python shell...$(NC)"
+	@echo -e "$(GREEN)Opening Odoo Python shell...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec openspp openspp-shell
 
 test: ## Run basic tests on the container
-	@echo "$(GREEN)Running container tests...$(NC)"
+	@echo -e "$(GREEN)Running container tests...$(NC)"
 	@echo "1. Testing image build..."
 	docker run --rm $(IMAGE_NAME):latest openspp-server --version
-	@echo "$(GREEN)✓ Version check passed$(NC)"
+	@echo -e "$(GREEN)✓ Version check passed$(NC)"
 	@echo ""
 	@echo "2. Testing health endpoint..."
 	docker-compose -f $(COMPOSE_FILE) up -d
@@ -113,63 +113,63 @@ test: ## Run basic tests on the container
 	@echo ""
 	@echo "3. Checking workers configuration..."
 	@docker-compose -f $(COMPOSE_FILE) exec openspp grep "workers" /etc/openspp/odoo.conf
-	@echo "$(GREEN)✓ Workers configuration checked$(NC)"
+	@echo -e "$(GREEN)✓ Workers configuration checked$(NC)"
 
 init-db: ## Initialize database with base modules
-	@echo "$(GREEN)Initializing OpenSPP database...$(NC)"
+	@echo -e "$(GREEN)Initializing OpenSPP database...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) run --rm \
 		-e INIT_DATABASE=true \
 		-e INSTALL_QUEUE_JOB=true \
 		openspp
-	@echo "$(GREEN)Database initialized. Restart required for queue_job.$(NC)"
+	@echo -e "$(GREEN)Database initialized. Restart required for queue_job.$(NC)"
 	@echo "Run: make restart"
 
 restart: ## Restart OpenSPP containers
-	@echo "$(YELLOW)Restarting OpenSPP containers...$(NC)"
+	@echo -e "$(YELLOW)Restarting OpenSPP containers...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) restart
-	@echo "$(GREEN)OpenSPP restarted$(NC)"
+	@echo -e "$(GREEN)OpenSPP restarted$(NC)"
 
 install-modules: ## Install OpenSPP modules (set MODULES env var)
-	@echo "$(GREEN)Installing modules: $(MODULES)$(NC)"
+	@echo -e "$(GREEN)Installing modules: $(MODULES)$(NC)"
 	docker-compose -f $(COMPOSE_FILE) run --rm \
 		-e INSTALL_MODULES="$(MODULES)" \
 		openspp
-	@echo "$(GREEN)Modules installed$(NC)"
+	@echo -e "$(GREEN)Modules installed$(NC)"
 
 update-modules: ## Update OpenSPP modules (set MODULES env var)
-	@echo "$(GREEN)Updating modules: $(MODULES)$(NC)"
+	@echo -e "$(GREEN)Updating modules: $(MODULES)$(NC)"
 	docker-compose -f $(COMPOSE_FILE) run --rm \
 		-e UPDATE_MODULES="$(MODULES)" \
 		openspp
-	@echo "$(GREEN)Modules updated$(NC)"
+	@echo -e "$(GREEN)Modules updated$(NC)"
 
 backup: ## Backup database and filestore
-	@echo "$(GREEN)Creating backup...$(NC)"
+	@echo -e "$(GREEN)Creating backup...$(NC)"
 	@mkdir -p backups
 	@docker-compose -f $(COMPOSE_FILE) exec db pg_dump -U openspp openspp | gzip > backups/openspp_$(shell date +%Y%m%d_%H%M%S).sql.gz
 	@docker-compose -f $(COMPOSE_FILE) exec openspp tar -czf - /var/lib/openspp > backups/filestore_$(shell date +%Y%m%d_%H%M%S).tar.gz
-	@echo "$(GREEN)Backup completed in ./backups/$(NC)"
+	@echo -e "$(GREEN)Backup completed in ./backups/$(NC)"
 
 push: ## Push images to Nexus registry
-	@echo "$(GREEN)Pushing images to $(PUSH_REGISTRY)...$(NC)"
-	@echo "$(YELLOW)Note: Make sure you're logged in: docker login $(PUSH_REGISTRY)$(NC)"
+	@echo -e "$(GREEN)Pushing images to $(PUSH_REGISTRY)...$(NC)"
+	@echo -e "$(YELLOW)Note: Make sure you're logged in: docker login $(PUSH_REGISTRY)$(NC)"
 	docker push $(PUSH_IMAGE_NAME):$(IMAGE_TAG)
 	docker push $(PUSH_IMAGE_NAME):latest
 	docker push $(PUSH_IMAGE_NAME):$(IMAGE_TAG)-slim
 	docker push $(PUSH_IMAGE_NAME):latest-slim
-	@echo "$(GREEN)Images pushed successfully$(NC)"
-	@echo "$(GREEN)Images available for public access at:$(NC)"
+	@echo -e "$(GREEN)Images pushed successfully$(NC)"
+	@echo -e "$(GREEN)Images available for public access at:$(NC)"
 	@echo "  $(IMAGE_NAME):$(IMAGE_TAG)"
 	@echo "  $(IMAGE_NAME):$(IMAGE_TAG)-slim"
 
 scan: ## Security scan with Trivy
-	@echo "$(GREEN)Scanning images for vulnerabilities...$(NC)"
+	@echo -e "$(GREEN)Scanning images for vulnerabilities...$(NC)"
 	@which trivy > /dev/null || (echo "$(RED)Trivy not installed. Install from: https://github.com/aquasecurity/trivy$(NC)" && exit 1)
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest-slim
 
 info: ## Show environment information
-	@echo "$(GREEN)OpenSPP Docker Environment Information$(NC)"
+	@echo -e "$(GREEN)OpenSPP Docker Environment Information$(NC)"
 	@echo "Image Tag: $(IMAGE_TAG)"
 	@echo "Public Registry: $(REGISTRY)"
 	@echo "Push Registry: $(PUSH_REGISTRY)"
@@ -178,21 +178,21 @@ info: ## Show environment information
 	@echo "Push Image: $(PUSH_IMAGE_NAME)"
 	@echo "APT Repository: https://builds.acn.fr/repository/apt-openspp-daily"
 	@echo ""
-	@echo "$(YELLOW)Container Status:$(NC)"
+	@echo -e "$(YELLOW)Container Status:$(NC)"
 	@docker-compose -f $(COMPOSE_FILE) ps
 	@echo ""
-	@echo "$(YELLOW)Image Information:$(NC)"
+	@echo -e "$(YELLOW)Image Information:$(NC)"
 	@docker images | grep openspp || echo "No OpenSPP images found"
 
 # Development helpers
 dev: ## Start in development mode (workers=0, dev mode enabled)
-	@echo "$(YELLOW)Starting in development mode (queue_job disabled)...$(NC)"
+	@echo -e "$(YELLOW)Starting in development mode (queue_job disabled)...$(NC)"
 	ODOO_DEV_MODE=true WORKERS=0 docker-compose -f $(COMPOSE_FILE) up -d
-	@echo "$(GREEN)Development mode started at http://localhost:8069$(NC)"
-	@echo "$(YELLOW)Warning: Queue jobs are disabled in dev mode$(NC)"
+	@echo -e "$(GREEN)Development mode started at http://localhost:8069$(NC)"
+	@echo -e "$(YELLOW)Warning: Queue jobs are disabled in dev mode$(NC)"
 
 prod-check: ## Validate production readiness
-	@echo "$(GREEN)Checking production readiness...$(NC)"
+	@echo -e "$(GREEN)Checking production readiness...$(NC)"
 	@echo -n "1. Checking workers configuration... "
 	@docker-compose -f $(COMPOSE_FILE) exec openspp grep "workers" /etc/openspp/odoo.conf | grep -q "workers = [2-9]" && echo "$(GREEN)✓$(NC)" || echo "$(RED)✗ Workers < 2$(NC)"
 	@echo -n "2. Checking queue_job in server_wide_modules... "
@@ -202,9 +202,9 @@ prod-check: ## Validate production readiness
 	@echo -n "4. Checking admin password... "
 	@docker-compose -f $(COMPOSE_FILE) exec openspp grep "admin_passwd" /etc/openspp/odoo.conf | grep -q "admin_passwd = admin" && echo "$(RED)✗ Using default password$(NC)" || echo "$(GREEN)✓$(NC)"
 	@echo ""
-	@echo "$(GREEN)Production check complete$(NC)"
+	@echo -e "$(GREEN)Production check complete$(NC)"
 
 login: ## Login to Nexus Docker registry
-	@echo "$(GREEN)Logging in to Nexus registry: $(PUSH_REGISTRY)$(NC)"
+	@echo -e "$(GREEN)Logging in to Nexus registry: $(PUSH_REGISTRY)$(NC)"
 	@docker login $(PUSH_REGISTRY)
-	@echo "$(GREEN)Successfully logged in to $(PUSH_REGISTRY)$(NC)"
+	@echo -e "$(GREEN)Successfully logged in to $(PUSH_REGISTRY)$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,19 @@ help: ## Show this help message
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-15s$(NC) %s\n", $$1, $$2}'
 
+bake: ## Build images using docker-bake.hcl
+	@echo -e "$(GREEN)Building OpenSPP image (Ubuntu 24.04)...$(NC)"
+	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
+	docker buildx bake \
+	    --no-cache \
+		-f docker-bake.hcl
+
 build: ## Build the standard Ubuntu-based image
 	@echo -e "$(GREEN)Building OpenSPP image (Ubuntu 24.04)...$(NC)"
 	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
-	docker build \
+	docker buildx build \
+	    --no-cache \
+		--platform linux/amd64 \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
 		-t $(IMAGE_NAME):$(IMAGE_TAG) \
@@ -41,7 +50,9 @@ build: ## Build the standard Ubuntu-based image
 build-slim: ## Build the lightweight Debian-based image
 	@echo -e "$(GREEN)Building OpenSPP slim image (Debian bookworm)...$(NC)"
 	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
-	docker build \
+	docker buildx build \
+	    --no-cache \
+		--platform linux/amd64 \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
 		-t $(IMAGE_NAME):$(IMAGE_TAG)-slim \

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ push: ## Push images to Nexus registry
 
 scan: ## Security scan with Trivy
 	@echo -e "$(GREEN)Scanning images for vulnerabilities...$(NC)"
-	@which trivy > /dev/null || (echo "$(RED)Trivy not installed. Install from: https://github.com/aquasecurity/trivy$(NC)" && exit 1)
+	@which trivy > /dev/null || (echo -e "$(RED)Trivy not installed. Install from: https://github.com/aquasecurity/trivy$(NC)" && exit 1)
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest-slim
 

--- a/NEXUS_DOCKER_SETUP.md
+++ b/NEXUS_DOCKER_SETUP.md
@@ -123,9 +123,11 @@ docker build -t openspp:latest .
 
 1. **Check secret names**: Ensure using the correct secret names (nexus_username vs nexus_user)
 2. **Verify credentials**: Test login manually:
+
    ```bash
    echo "your-password" | docker login 172.20.0.26:8082 -u "your-username" --password-stdin
    ```
+
 3. **Check network access**: Ensure the CI runner can reach 172.20.0.26:8082
 
 ### Push Failures

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ cd openspp-packaging-docker
 2. Build and start the services:
 ```bash
 # Build the image (pulls from APT repository)
-docker-compose build
+docker compose build
 
 # Start the services
-docker-compose up -d
+docker compose up -d
 ```
 
 3. Initialize the database (first run only):
 ```bash
-docker-compose exec openspp env INIT_DATABASE=true openspp-server
+docker compose exec openspp env INIT_DATABASE=true openspp-server
 ```
 
 4. Access OpenSPP at http://localhost:8069
@@ -175,7 +175,7 @@ echo "redis_password" | docker secret create redis_password -
 
 2. Deploy with production configuration:
 ```bash
-docker-compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml up -d
 ```
 
 ### Kubernetes Deployment
@@ -288,14 +288,14 @@ docker exec openspp env UPDATE_MODULES=base,web openspp-server
 1. Place addons in `custom-addons/` directory
 2. Restart container to detect new modules:
 ```bash
-docker-compose restart openspp
+docker compose restart openspp
 ```
 
 ### Debugging
 
 Enable development mode:
 ```bash
-docker-compose exec openspp env ODOO_DEV_MODE=true openspp-server
+docker compose exec openspp env ODOO_DEV_MODE=true openspp-server
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ docker run -d \
   -e DB_HOST=db \
   -e DB_USER=openspp \
   -e DB_PASSWORD=openspp \
+  -e DB_NAME=openspp \
+  -e DB_PORT=5432 \
   -e ODOO_ADMIN_PASSWORD=admin \
   docker.acn.fr/openspp/openspp:latest
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Production-ready Docker images for OpenSPP Social Protection Platform based on Odoo 17.
 
-> **Note:** This configuration uses OpenSPP daily builds from the [apt-openspp-daily](https://builds.acn.fr/repository/apt-openspp-daily/) repository. The package name is `openspp-17-daily`.
+> [!NOTE]  
+> This configuration uses OpenSPP daily builds from the [apt-openspp-daily](https://builds.acn.fr/repository/apt-openspp-daily/) repository. The package name is `openspp-17-daily`.
 
 ## Docker Registry
 
@@ -26,6 +27,9 @@ Images are hosted on ACN Nexus Docker Registry:
 ## Quick Start
 
 ### Using Docker Compose (Development)
+
+> [!CAUTION]  
+> The docker-compose.yml file is configured for development use only. For production deployments, please refer to the official documentation.
 
 1. Clone this repository:
 
@@ -87,14 +91,14 @@ docker run -d \
 ### Standard Image (Ubuntu 24.04 LTS)
 
 - **Base**: Ubuntu 24.04 LTS
-- **Size**: ~1.5GB
+- **Size**: ~2.26GB
 - **Use case**: Production deployments requiring maximum compatibility
 - **Tag**: `docker.acn.fr/openspp/openspp:latest`
 
 ### Slim Image (Debian Bookworm)
 
 - **Base**: Debian bookworm-slim
-- **Size**: ~1.0GB
+- **Size**: ~1.92GB
 - **Use case**: Resource-constrained environments
 - **Tag**: `docker.acn.fr/openspp/openspp:latest-slim`
 
@@ -173,6 +177,7 @@ docker exec openspp grep workers /etc/openspp/odoo.conf
 # Navigate to Settings > Technical > Queue Job > Jobs
 ```
 
+<!--
 ## Production Deployment
 
 ### Using Docker Compose
@@ -192,6 +197,7 @@ docker exec openspp grep workers /etc/openspp/odoo.conf
    ```bash
    docker compose -f docker-compose.prod.yml up -d
    ```
+-->
 
 ### Kubernetes Deployment
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Production-ready Docker images for OpenSPP Social Protection Platform based on O
 ## Docker Registry
 
 Images are hosted on ACN Nexus Docker Registry:
+
 - **Public access (pull):** `docker.acn.fr/openspp/openspp`
 - **Push access:** `docker-push.acn.fr/openspp/openspp` (requires authentication)
 
@@ -27,28 +28,32 @@ Images are hosted on ACN Nexus Docker Registry:
 ### Using Docker Compose (Development)
 
 1. Clone this repository:
-```bash
-git clone https://github.com/openspp/openspp-packaging-docker.git
-cd openspp-packaging-docker
-```
+
+   ```bash
+   git clone https://github.com/openspp/openspp-packaging-docker.git
+   cd openspp-packaging-docker
+   ```
 
 2. Build and start the services:
-```bash
-# Build the image (pulls from APT repository)
-docker compose build
 
-# Start the services
-docker compose up -d
-```
+   ```bash
+   # Build the image (pulls from APT repository)
+   docker compose build
+
+   # Start the services
+   docker compose up -d
+   ```
 
 3. Initialize the database (first run only):
-```bash
-docker compose exec openspp env INIT_DATABASE=true openspp-server
-```
 
-4. Access OpenSPP at http://localhost:8069
+   ```bash
+   docker compose exec openspp env INIT_DATABASE=true openspp-server
+   ```
+
+4. Access OpenSPP at [http://localhost:8069](http://localhost:8069)
 
 Default credentials:
+
 - Username: admin
 - Password: admin
 
@@ -80,12 +85,14 @@ docker run -d \
 ## Image Variants
 
 ### Standard Image (Ubuntu 24.04 LTS)
+
 - **Base**: Ubuntu 24.04 LTS
 - **Size**: ~1.5GB
 - **Use case**: Production deployments requiring maximum compatibility
 - **Tag**: `docker.acn.fr/openspp/openspp:latest`
 
 ### Slim Image (Debian Bookworm)
+
 - **Base**: Debian bookworm-slim
 - **Size**: ~1.0GB
 - **Use case**: Resource-constrained environments
@@ -96,6 +103,7 @@ docker run -d \
 ### Environment Variables
 
 #### Database Configuration
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DB_HOST` | `db` | PostgreSQL host |
@@ -105,6 +113,7 @@ docker run -d \
 | `DB_NAME` | `openspp` | Database name |
 
 #### Odoo Configuration
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ODOO_ADMIN_PASSWORD` | random | Master admin password |
@@ -114,6 +123,7 @@ docker run -d \
 | `ODOO_PROXY_MODE` | `False` | Enable proxy mode |
 
 #### Initialization
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `INIT_DATABASE` | `false` | Initialize database on startup |
@@ -141,7 +151,8 @@ docker run -d \
 
 OpenSPP requires the `queue_job` module for asynchronous operations. **This is CRITICAL for proper functioning.**
 
-### Requirements:
+### Requirements
+
 1. **Workers MUST be > 0** (minimum 2 for production)
    - Set `ODOO_WORKERS=2` or higher
    - Development mode (`ODOO_DEV_MODE=true`) sets workers to 0, disabling queue_job
@@ -150,8 +161,10 @@ OpenSPP requires the `queue_job` module for asynchronous operations. **This is C
    - On first run with `INIT_DATABASE=true`, queue_job is installed automatically
    - **Restart required** after installing queue_job for the job runner to start
 
-### Verification:
+### Verification
+
 Check if queue jobs are running:
+
 ```bash
 # Check workers configuration
 docker exec openspp grep workers /etc/openspp/odoo.conf
@@ -165,18 +178,20 @@ docker exec openspp grep workers /etc/openspp/odoo.conf
 ### Using Docker Compose
 
 1. Create Docker secrets:
-```bash
-echo "openspp" | docker secret create db_name -
-echo "openspp" | docker secret create db_user -
-echo "strong_password" | docker secret create db_password -
-echo "admin_password" | docker secret create admin_password -
-echo "redis_password" | docker secret create redis_password -
-```
+
+   ```bash
+   echo "openspp" | docker secret create db_name -
+   echo "openspp" | docker secret create db_user -
+   echo "strong_password" | docker secret create db_password -
+   echo "admin_password" | docker secret create admin_password -
+   echo "redis_password" | docker secret create redis_password -
+   ```
 
 2. Deploy with production configuration:
-```bash
-docker compose -f docker-compose.prod.yml up -d
-```
+
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d
+   ```
 
 ### Kubernetes Deployment
 
@@ -209,7 +224,7 @@ make build-all
 docker buildx build --platform linux/amd64,linux/arm64 -t openspp:local .
 ```
 
-Note: The images automatically install the latest daily build from the OpenSPP APT repository at https://builds.acn.fr/repository/apt-openspp-daily/
+Note: The images automatically install the latest daily build from the OpenSPP APT repository at [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 
 ### Pushing to Nexus Registry
 
@@ -224,12 +239,14 @@ make push
 ```
 
 Images will be available at:
+
 - `docker.acn.fr/openspp/openspp:latest` (public access)
 - `docker.acn.fr/openspp/openspp:latest-slim` (public access)
 
 ### CI/CD Pipeline
 
 The Woodpecker CI pipeline automatically:
+
 1. Creates multi-arch Docker images (pulling from APT repository)
 2. Runs security scans with Trivy
 3. Tests the images
@@ -240,6 +257,7 @@ The Woodpecker CI pipeline automatically:
 ### Health Check
 
 The container includes a health check endpoint:
+
 ```bash
 curl http://localhost:8069/web/health
 ```
@@ -247,6 +265,7 @@ curl http://localhost:8069/web/health
 ### Logs
 
 View container logs:
+
 ```bash
 docker logs -f openspp
 ```
@@ -254,6 +273,7 @@ docker logs -f openspp
 ### Metrics
 
 For production monitoring, consider:
+
 - Prometheus + Grafana for metrics
 - ELK/EFK stack for log aggregation
 - APM tools like New Relic or DataDog
@@ -261,6 +281,7 @@ For production monitoring, consider:
 ## Troubleshooting
 
 ### Database Connection Issues
+
 ```bash
 # Check database connectivity
 docker exec openspp pg_isready -h db -U openspp
@@ -270,12 +291,14 @@ docker logs openspp | grep -i database
 ```
 
 ### Permission Issues
+
 ```bash
 # Fix volume permissions
 docker exec -u root openspp chown -R openspp:openspp /var/lib/openspp
 ```
 
 ### Module Installation
+
 ```bash
 # Install modules manually
 docker exec openspp env UPDATE_MODULES=base,web openspp-server
@@ -287,6 +310,7 @@ docker exec openspp env UPDATE_MODULES=base,web openspp-server
 
 1. Place addons in `custom-addons/` directory
 2. Restart container to detect new modules:
+
 ```bash
 docker compose restart openspp
 ```
@@ -294,6 +318,7 @@ docker compose restart openspp
 ### Debugging
 
 Enable development mode:
+
 ```bash
 docker compose exec openspp env ODOO_DEV_MODE=true openspp-server
 ```
@@ -304,10 +329,10 @@ LGPL-3.0 - See [LICENSE](LICENSE) file for details.
 
 ## Support
 
-- Documentation: https://docs.openspp.org
-- Issues: https://github.com/openspp/openspp-packaging-docker/issues
-- Community: https://community.openspp.org
-- APT Repository (Daily): https://builds.acn.fr/repository/apt-openspp-daily/
+- Documentation: [https://docs.openspp.org](https://docs.openspp.org)
+- Issues: [https://github.com/openspp/openspp-packaging-docker/issues](https://github.com/openspp/openspp-packaging-docker/issues)
+- Community: [https://community.openspp.org](https://community.openspp.org)
+- APT Repository (Daily): [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 
 ## Contributing
 

--- a/TEST.md
+++ b/TEST.md
@@ -28,40 +28,44 @@ chmod +x test-images.sh
 ### Manual Testing with Docker Compose
 
 1. **Test the latest images from registry:**
-```bash
-# Start services
-docker-compose -f docker-compose.test.yml up -d
 
-# Watch logs
-docker-compose -f docker-compose.test.yml logs -f
+   ```bash
+   # Start services
+   docker-compose -f docker-compose.test.yml up -d
 
-# Access OpenSPP
-open http://localhost:8069
+   # Watch logs
+   docker-compose -f docker-compose.test.yml logs -f
 
-# Stop services
-docker-compose -f docker-compose.test.yml down -v
-```
+   # Access OpenSPP
+   open http://localhost:8069
+
+   # Stop services
+   docker-compose -f docker-compose.test.yml down -v
+   ```
 
 2. **Test specific image tags:**
-```bash
-# Test weekly build
-IMAGE_TAG=weekly docker-compose -f docker-compose.test.yml up -d
 
-# Test specific version
-IMAGE_TAG=v1.0.0 docker-compose -f docker-compose.test.yml up -d
+   ```bash
+   # Test weekly build
+   IMAGE_TAG=weekly docker-compose -f docker-compose.test.yml up -d
 
-# Test slim variant
-IMAGE_TAG=latest-slim docker-compose -f docker-compose.test.yml up -d
-```
+   # Test specific version
+   IMAGE_TAG=v1.0.0 docker-compose -f docker-compose.test.yml up -d
+
+   # Test slim variant
+   IMAGE_TAG=latest-slim docker-compose -f docker-compose.test.yml up -d
+   ```
 
 3. **Test with database initialization:**
-```bash
-INIT_DATABASE=true docker-compose -f docker-compose.test.yml up -d
-```
+
+   ```bash
+   INIT_DATABASE=true docker-compose -f docker-compose.test.yml up -d
+   ```
 
 ## Test Scenarios
 
 ### 1. Basic Functionality Test
+
 - ✅ Image pulls successfully
 - ✅ Container starts without errors
 - ✅ Health endpoint responds
@@ -69,6 +73,7 @@ INIT_DATABASE=true docker-compose -f docker-compose.test.yml up -d
 - ✅ Can connect to PostgreSQL
 
 ### 2. Database Operations Test
+
 ```bash
 # Initialize database with modules
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -80,6 +85,7 @@ docker-compose -f docker-compose.test.yml exec openspp \
 ```
 
 ### 3. Performance Test
+
 ```bash
 # Check response time
 time curl -s http://localhost:8069 > /dev/null
@@ -92,6 +98,7 @@ ab -n 100 -c 10 http://localhost:8069/
 ```
 
 ### 4. Module Installation Test
+
 ```bash
 # Install OpenSPP modules
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -101,6 +108,7 @@ docker-compose -f docker-compose.test.yml exec openspp \
 ```
 
 ### 5. Multi-Architecture Test
+
 ```bash
 # Test on different architectures (if available)
 docker run --rm --platform linux/amd64 \
@@ -111,12 +119,14 @@ docker run --rm --platform linux/amd64 \
 ## Validation Checklist
 
 ### Image Build Validation
+
 - [ ] Image size is reasonable (~1.5GB for Ubuntu, ~1.0GB for slim)
 - [ ] No security vulnerabilities in base image
 - [ ] All required files are present
 - [ ] Proper user permissions (non-root)
 
 ### Runtime Validation
+
 - [ ] Container starts successfully
 - [ ] No critical errors in logs
 - [ ] Health check passes
@@ -126,6 +136,7 @@ docker run --rm --platform linux/amd64 \
 - [ ] Custom addons can be loaded
 
 ### Security Validation
+
 - [ ] Running as non-root user (openspp)
 - [ ] No exposed secrets in environment
 - [ ] Proper file permissions
@@ -134,6 +145,7 @@ docker run --rm --platform linux/amd64 \
 ## Debugging Failed Tests
 
 ### Container Won't Start
+
 ```bash
 # Check logs
 docker-compose -f docker-compose.test.yml logs openspp
@@ -146,6 +158,7 @@ docker-compose -f docker-compose.test.yml run openspp /bin/bash
 ```
 
 ### Database Connection Issues
+
 ```bash
 # Test database connectivity
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -156,6 +169,7 @@ docker-compose -f docker-compose.test.yml logs db
 ```
 
 ### Module Import Errors
+
 ```bash
 # Check Python environment
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -181,11 +195,13 @@ REGISTRY=localhost:5000 docker-compose -f docker-compose.test.yml up -d
 ## Automated CI Testing
 
 The GitHub Actions workflow automatically tests images on:
+
 - Pull requests
 - Weekly scheduled builds
 - Manual workflow dispatches
 
 To manually trigger tests:
+
 1. Go to [Actions](https://github.com/OpenSPP/openspp-packaging-docker/actions)
 2. Select "Docker Build and Push"
 3. Click "Run workflow"
@@ -212,6 +228,7 @@ docker rmi $(docker images | grep openspp | awk '{print $3}')
 ## Reporting Issues
 
 If tests fail:
+
 1. Capture the error logs
 2. Note the image tag and registry
 3. Document the test scenario

--- a/WOODPECKER_AGENT_SETUP.md
+++ b/WOODPECKER_AGENT_SETUP.md
@@ -19,7 +19,7 @@ docker --version
 
 Since the Nexus Docker registry at `172.20.0.26:8082` uses HTTP (not HTTPS), the Docker daemon on the Woodpecker agent host must be configured to allow this insecure registry.
 
-#### Edit Docker daemon configuration:
+#### Edit Docker daemon configuration
 
 ```bash
 sudo nano /etc/docker/daemon.json
@@ -33,13 +33,13 @@ Add or update the configuration:
 }
 ```
 
-#### Restart Docker:
+#### Restart Docker
 
 ```bash
 sudo systemctl restart docker
 ```
 
-#### Verify the configuration:
+#### Verify the configuration
 
 ```bash
 docker info | grep -A 5 "Insecure Registries"
@@ -52,6 +52,7 @@ You should see `172.20.0.26:8082` listed.
 The Woodpecker agent must have access to the Docker socket. This is typically at `/var/run/docker.sock`.
 
 Verify the socket exists:
+
 ```bash
 ls -la /var/run/docker.sock
 ```
@@ -59,10 +60,12 @@ ls -la /var/run/docker.sock
 ### 4. Network Access
 
 The agent must be able to reach:
+
 - `172.20.0.26:8082` - Nexus Docker registry (internal network)
 - GitHub for cloning repositories
 
 Test connectivity:
+
 ```bash
 # Test Nexus registry
 curl -I http://172.20.0.26:8082/v2/
@@ -104,6 +107,7 @@ docker run -d \
 ### "Cannot connect to Docker daemon"
 
 Ensure:
+
 1. Docker is running on the host
 2. The socket is mounted correctly
 3. The agent has permissions to access the socket
@@ -115,6 +119,7 @@ This means the insecure-registries configuration is missing. Add `172.20.0.26:80
 ### "unauthorized: authentication required"
 
 Check:
+
 1. Nexus credentials are correct
 2. The user has push permissions to the repository
 3. The repository exists in Nexus
@@ -129,6 +134,7 @@ Check:
 ## Alternative: Docker-in-Docker
 
 If socket mounting is not desired, you can use Docker-in-Docker (DinD), but this requires:
+
 - Privileged mode (security risk)
 - More complex configuration
 - Potential performance overhead

--- a/WOODPECKER_AUTH_TROUBLESHOOTING.md
+++ b/WOODPECKER_AUTH_TROUBLESHOOTING.md
@@ -1,8 +1,10 @@
 # Woodpecker CI Authentication Troubleshooting
 
 ## Issue
+
 The Woodpecker CI pipeline is failing with authentication errors when trying to push to the Nexus Docker registry:
-```
+
+``` text
 Logging in with username '********' to registry 'docker-push.acn.fr'
 ERR execution failed error="error authenticating: exit status 1"
 ```
@@ -10,23 +12,29 @@ ERR execution failed error="error authenticating: exit status 1"
 ## Possible Causes
 
 ### 1. Secret Names Mismatch
+
 The GitHub Actions workflow uses uppercase secret names:
+
 - `NEXUS_USERNAME`
 - `NEXUS_PASSWORD`
 
 While Woodpecker configuration uses lowercase:
+
 - `nexus_username`
 - `nexus_password`
 
 **Solution**: Ensure secrets are configured in Woodpecker with the exact same names used in the pipeline.
 
 ### 2. Secret Configuration in Woodpecker
+
 Secrets need to be properly configured in Woodpecker either:
+
 - **Repository secrets**: Add via Woodpecker UI under repository settings
 - **Organization secrets**: Add at organization level if using shared credentials
 - **Global secrets**: Configure in Woodpecker server for all repositories
 
 **To add secrets in Woodpecker UI:**
+
 1. Go to your repository in Woodpecker
 2. Click on Settings → Secrets
 3. Add new secrets:
@@ -36,35 +44,44 @@ Secrets need to be properly configured in Woodpecker either:
    - Value: Your Nexus password
 
 ### 3. Plugin Authentication Format
+
 The `woodpeckerci/plugin-docker-buildx` plugin might have issues with certain authentication methods.
 
 **Alternative approaches provided:**
 
 #### Option A: Debug Configuration (`.woodpecker-debug.yml`)
+
 Use this to test secret availability and manual Docker login:
+
 ```bash
 # Rename to .woodpecker.yml to test
 mv .woodpecker-debug.yml .woodpecker.yml
 ```
 
 #### Option B: Alternative Configuration (`.woodpecker-alt.yml`)
+
 Uses Docker commands directly instead of the plugin:
+
 ```bash
 # Rename to .woodpecker.yml to use
 mv .woodpecker-alt.yml .woodpecker.yml
 ```
 
 ### 4. Registry URL Format
+
 Ensure the registry URL is correct:
+
 - Push URL: `docker-push.acn.fr`
 - Pull URL: `docker.acn.fr`
 
 ### 5. Permissions
+
 The repository must be marked as "Trusted" in Woodpecker to use privileged mode required for Docker builds.
 
 ## Testing Steps
 
 1. **Test secret availability:**
+
    ```bash
    # Use the debug configuration
    cp .woodpecker-debug.yml .woodpecker.yml
@@ -84,7 +101,9 @@ The repository must be marked as "Trusted" in Woodpecker to use privileged mode 
    If the plugin continues to fail, use the alternative configuration that bypasses the plugin.
 
 ## Working GitHub Actions Reference
+
 The GitHub Actions workflow (`.github/workflows/docker-build.yml`) successfully authenticates using:
+
 ```yaml
 - name: Log in to Nexus Registry
   uses: docker/login-action@v3

--- a/WOODPECKER_FIX.md
+++ b/WOODPECKER_FIX.md
@@ -30,6 +30,7 @@ The new configuration (`.woodpecker-working.yml`) uses the same pattern as the w
 ## Key Changes
 
 ### Before (Not Working)
+
 ```yaml
 build:
   image: woodpeckerci/plugin-docker-buildx
@@ -43,6 +44,7 @@ build:
 ```
 
 ### After (Working)
+
 ```yaml
 build:
   image: docker:latest
@@ -56,6 +58,7 @@ build:
 ## Required Secrets
 
 Ensure these secrets are configured in Woodpecker:
+
 - `nexus_username` or `nexus_user`
 - `nexus_password`
 

--- a/analyze-layers.sh
+++ b/analyze-layers.sh
@@ -2,7 +2,7 @@
 # ABOUTME: Script to analyze Docker image layers and find redundancy
 # ABOUTME: Helps identify duplicate layers and optimization opportunities
 
-set -e
+set -euo pipefail
 
 # Colors
 RED='\033[0;31m'
@@ -19,9 +19,9 @@ echo "================================================"
 
 # Check if image exists
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    echo -e "${RED}Error: Image '$IMAGE' not found${NC}"
-    echo "Usage: $0 [image-name]"
-    exit 1
+  echo -e "${RED}Error: Image '$IMAGE' not found${NC}"
+  echo "Usage: $0 [image-name]"
+  exit 1
 fi
 
 # 1. Show layer sizes
@@ -30,14 +30,14 @@ docker history "$IMAGE" --format "table {{.Size}}\t{{.CreatedBy}}" | head -20
 
 # 2. Find duplicate sizes
 echo -e "\n${YELLOW}Checking for duplicate layer sizes:${NC}"
-docker history "$IMAGE" --format "{{.Size}}" | \
-    grep -v "<missing>" | \
-    sort | uniq -d | while read size; do
-    if [ ! -z "$size" ] && [ "$size" != "0B" ]; then
-        echo -e "${RED}Found duplicate size: $size${NC}"
-        echo "Layers with this size:"
-        docker history "$IMAGE" --format "{{.Size}}\t{{.CreatedBy}}" | grep "^$size"
-    fi
+docker history "$IMAGE" --format "{{.Size}}" |
+  grep -v "<missing>" |
+  sort | uniq -d | while read -r size; do
+  if [ ! -z "$size" ] && [ "$size" != "0B" ]; then
+    echo -e "${RED}Found duplicate size: $size${NC}"
+    echo "Layers with this size:"
+    docker history "$IMAGE" --format "{{.Size}}\t{{.CreatedBy}}" | grep "^$size"
+  fi
 done
 
 # 3. Calculate total image size
@@ -48,58 +48,58 @@ echo "Total image size: ${SIZE_MB}MB"
 
 # 4. Show largest layers
 echo -e "\n${YELLOW}Top 5 Largest Layers:${NC}"
-docker history "$IMAGE" --format "table {{.Size}}\t{{.CreatedBy}}" | \
-    grep -v SIZE | \
-    sort -hr | \
-    head -5
+docker history "$IMAGE" --format "table {{.Size}}\t{{.CreatedBy}}" |
+  grep -v SIZE |
+  sort -hr |
+  head -5
 
 # 5. Check for common anti-patterns
 echo -e "\n${YELLOW}Checking for common anti-patterns:${NC}"
 
 # Check for chown after COPY
-if docker history "$IMAGE" --no-trunc | grep -q "COPY.*from=.*installer" && \
-   docker history "$IMAGE" --no-trunc | grep -q "chown.*openspp"; then
-    echo -e "${RED}⚠ Warning: Found COPY followed by chown - consider using COPY --chown${NC}"
+if docker history "$IMAGE" --no-trunc | grep -q "COPY.*from=.*installer" &&
+  docker history "$IMAGE" --no-trunc | grep -q "chown.*openspp"; then
+  echo -e "${RED}⚠ Warning: Found COPY followed by chown - consider using COPY --chown${NC}"
 fi
 
 # Check for multiple apt-get updates
 APT_UPDATES=$(docker history "$IMAGE" --no-trunc | grep -c "apt-get update" || true)
 if [ "$APT_UPDATES" -gt 2 ]; then
-    echo -e "${YELLOW}⚠ Found $APT_UPDATES apt-get update commands - consider combining${NC}"
+  echo -e "${YELLOW}⚠ Found $APT_UPDATES apt-get update commands - consider combining${NC}"
 fi
 
 # Check for rm commands that might be ineffective
 if docker history "$IMAGE" --no-trunc | grep -q "rm -rf /var/lib/apt/lists"; then
-    echo -e "${GREEN}✓ Good: Cleaning apt cache${NC}"
+  echo -e "${GREEN}✓ Good: Cleaning apt cache${NC}"
 fi
 
 # 6. Suggest dive tool if not installed
-if ! command -v dive &> /dev/null; then
-    echo -e "\n${BLUE}For detailed layer analysis, install dive:${NC}"
-    echo "  brew install dive    # macOS"
-    echo "  wget https://github.com/wagoodman/dive/releases/latest/download/dive_*_linux_amd64.deb"
-    echo "  sudo dpkg -i dive_*.deb    # Ubuntu/Debian"
-    echo ""
-    echo "Then run: dive $IMAGE"
+if ! command -v dive &>/dev/null; then
+  echo -e "\n${BLUE}For detailed layer analysis, install dive:${NC}"
+  echo "  brew install dive    # macOS"
+  echo "  wget https://github.com/wagoodman/dive/releases/latest/download/dive_*_linux_amd64.deb"
+  echo "  sudo dpkg -i dive_*.deb    # Ubuntu/Debian"
+  echo ""
+  echo "Then run: dive $IMAGE"
 else
-    echo -e "\n${GREEN}Dive is installed. Run 'dive $IMAGE' for interactive analysis${NC}"
+  echo -e "\n${GREEN}Dive is installed. Run 'dive $IMAGE' for interactive analysis${NC}"
 fi
 
 # 7. Export detailed analysis
 echo -e "\n${YELLOW}Exporting detailed analysis...${NC}"
 REPORT_FILE="layer-analysis-$(date +%Y%m%d-%H%M%S).txt"
 {
-    echo "Docker Layer Analysis Report"
-    echo "Image: $IMAGE"
-    echo "Date: $(date)"
-    echo "================================"
-    echo ""
-    echo "Full Layer History:"
-    docker history --no-trunc "$IMAGE"
-    echo ""
-    echo "Layer SHA256 Hashes:"
-    docker inspect "$IMAGE" | jq '.[0].RootFS.Layers'
-} > "$REPORT_FILE"
+  echo "Docker Layer Analysis Report"
+  echo "Image: $IMAGE"
+  echo "Date: $(date)"
+  echo "================================"
+  echo ""
+  echo "Full Layer History:"
+  docker history --no-trunc "$IMAGE"
+  echo ""
+  echo "Layer SHA256 Hashes:"
+  docker inspect "$IMAGE" | jq '.[0].RootFS.Layers'
+} >"$REPORT_FILE"
 
 echo -e "${GREEN}Detailed report saved to: $REPORT_FILE${NC}"
 

--- a/ci-docker-push.sh
+++ b/ci-docker-push.sh
@@ -2,19 +2,17 @@
 # ABOUTME: Push Docker images to Nexus registry using internal IP
 # ABOUTME: Based on working pattern from openspp-packaging-v2
 
-set -e
+set -euo pipefail
 
 # Configuration - using internal Docker network IP
 NEXUS_DOCKER="172.20.0.26:8082"
-NEXUS_USER="${NEXUS_USER}"
-NEXUS_PASSWORD="${NEXUS_PASSWORD}"
 
 # Check credentials
 if [ -z "$NEXUS_USER" ] || [ -z "$NEXUS_PASSWORD" ]; then
-    echo "Error: NEXUS_USER and NEXUS_PASSWORD must be set"
-    echo "Try: export NEXUS_USER=your_username"
-    echo "     export NEXUS_PASSWORD=your_password"
-    exit 1
+  echo "Error: NEXUS_USER and NEXUS_PASSWORD must be set"
+  echo "Try: export NEXUS_USER=your_username"
+  echo "     export NEXUS_PASSWORD=your_password"
+  exit 1
 fi
 
 echo "=== Docker Push to Nexus Registry ==="
@@ -24,31 +22,31 @@ echo
 # Test connectivity
 echo "Testing connection to Nexus Docker registry..."
 if nc -zv 172.20.0.26 8082 2>/dev/null; then
-    echo "✓ Port 8082 is reachable"
+  echo "✓ Port 8082 is reachable"
 else
-    echo "✗ Cannot reach 172.20.0.26:8082"
-    echo "  This script must run from within the Docker network"
-    exit 1
+  echo "✗ Cannot reach 172.20.0.26:8082"
+  echo "  This script must run from within the Docker network"
+  exit 1
 fi
 
 # Login to registry
 echo "Logging in to Docker registry..."
-echo "$NEXUS_PASSWORD" | docker login "$NEXUS_DOCKER" -u "$NEXUS_USER" --password-stdin
-if [ $? -eq 0 ]; then
-    echo "✓ Login successful"
+
+if [ "$(echo "$NEXUS_PASSWORD" | docker login "$NEXUS_DOCKER" -u "$NEXUS_USER" --password-stdin)" -eq 0 ]; then
+  echo "✓ Login successful"
 else
-    echo "✗ Login failed"
-    echo "  Check credentials and registry configuration"
-    exit 1
+  echo "✗ Login failed"
+  echo "  Check credentials and registry configuration"
+  exit 1
 fi
 
 # Determine what to push
 if [ -n "$1" ]; then
-    # Specific image provided
-    SOURCE_IMAGE="$1"
+  # Specific image provided
+  SOURCE_IMAGE="$1"
 else
-    # Default to openspp:latest
-    SOURCE_IMAGE="openspp:latest"
+  # Default to openspp:latest
+  SOURCE_IMAGE="openspp:latest"
 fi
 
 echo
@@ -56,20 +54,20 @@ echo "Preparing to push: $SOURCE_IMAGE"
 
 # Check if image exists locally
 if ! docker image inspect "$SOURCE_IMAGE" >/dev/null 2>&1; then
-    echo "✗ Image not found locally: $SOURCE_IMAGE"
-    echo "  Build it first with: docker build -t $SOURCE_IMAGE ."
-    exit 1
+  echo "✗ Image not found locally: $SOURCE_IMAGE"
+  echo "  Build it first with: docker build -t $SOURCE_IMAGE ."
+  exit 1
 fi
 
 # Tag for Nexus registry
 TARGET_IMAGE="$NEXUS_DOCKER/openspp/openspp:latest"
 if [ "$SOURCE_IMAGE" != "openspp:latest" ]; then
-    # Preserve specific tags
-    TAG="${SOURCE_IMAGE#*:}"
-    if [ "$TAG" = "$SOURCE_IMAGE" ]; then
-        TAG="latest"
-    fi
-    TARGET_IMAGE="$NEXUS_DOCKER/openspp/openspp:$TAG"
+  # Preserve specific tags
+  TAG="${SOURCE_IMAGE#*:}"
+  if [ "$TAG" = "$SOURCE_IMAGE" ]; then
+    TAG="latest"
+  fi
+  TARGET_IMAGE="$NEXUS_DOCKER/openspp/openspp:$TAG"
 fi
 
 echo "Tagging as: $TARGET_IMAGE"
@@ -78,37 +76,37 @@ docker tag "$SOURCE_IMAGE" "$TARGET_IMAGE"
 # Push to registry
 echo "Pushing image..."
 if docker push "$TARGET_IMAGE"; then
-    echo "✓ Successfully pushed: $TARGET_IMAGE"
+  echo "✓ Successfully pushed: $TARGET_IMAGE"
 else
-    echo "✗ Push failed"
-    exit 1
+  echo "✗ Push failed"
+  exit 1
 fi
 
 # Also push additional tags if this is a release
 if [ -n "$CI_COMMIT_TAG" ]; then
-    echo
-    echo "Detected tag: $CI_COMMIT_TAG"
-    
-    # Push with version tag
-    VERSION_TAG="$NEXUS_DOCKER/openspp/openspp:$CI_COMMIT_TAG"
-    docker tag "$SOURCE_IMAGE" "$VERSION_TAG"
-    docker push "$VERSION_TAG"
-    echo "✓ Pushed version tag: $VERSION_TAG"
-    
-    # Update latest tag
-    LATEST_TAG="$NEXUS_DOCKER/openspp/openspp:latest"
-    docker tag "$SOURCE_IMAGE" "$LATEST_TAG"
-    docker push "$LATEST_TAG"
-    echo "✓ Updated latest tag: $LATEST_TAG"
+  echo
+  echo "Detected tag: $CI_COMMIT_TAG"
+
+  # Push with version tag
+  VERSION_TAG="$NEXUS_DOCKER/openspp/openspp:$CI_COMMIT_TAG"
+  docker tag "$SOURCE_IMAGE" "$VERSION_TAG"
+  docker push "$VERSION_TAG"
+  echo "✓ Pushed version tag: $VERSION_TAG"
+
+  # Update latest tag
+  LATEST_TAG="$NEXUS_DOCKER/openspp/openspp:latest"
+  docker tag "$SOURCE_IMAGE" "$LATEST_TAG"
+  docker push "$LATEST_TAG"
+  echo "✓ Updated latest tag: $LATEST_TAG"
 fi
 
 # Push commit SHA tag if available
 if [ -n "$CI_COMMIT_SHA" ]; then
-    SHORT_SHA="${CI_COMMIT_SHA:0:8}"
-    SHA_TAG="$NEXUS_DOCKER/openspp/openspp:$SHORT_SHA"
-    docker tag "$SOURCE_IMAGE" "$SHA_TAG"
-    docker push "$SHA_TAG"
-    echo "✓ Pushed commit tag: $SHA_TAG"
+  SHORT_SHA="${CI_COMMIT_SHA:0:8}"
+  SHA_TAG="$NEXUS_DOCKER/openspp/openspp:$SHORT_SHA"
+  docker tag "$SOURCE_IMAGE" "$SHA_TAG"
+  docker push "$SHA_TAG"
+  echo "✓ Pushed commit tag: $SHA_TAG"
 fi
 
 echo

--- a/config/odoo.conf
+++ b/config/odoo.conf
@@ -57,7 +57,7 @@ log_db = False
 log_handler = :INFO
 log_level = info
 logfile = False
-longpolling_port = 8072
+gevent_port = 8072
 syslog = False
 
 ; ============================================
@@ -82,25 +82,12 @@ smtp_user = False
 smtp_password = False
 
 ; ============================================
-; Queue Job Configuration (Required for OpenSPP)
-; ============================================
-[queue_job]
-channels = root:2
-; Database connection for job runner (uses main database settings if not specified)
-jobrunner_db_host = 
-jobrunner_db_port = 5432
-jobrunner_db_user = 
-jobrunner_db_password = 
-
-; ============================================
 ; Misc
 ; ============================================
 csv_internal_sep = ,
 db_sslmode = prefer
 demo = {}
 import_partial = 
-osv_memory_age_limit = 1.0
-osv_memory_count_limit = False
 pg_path = 
 pidfile = 
 reportgz = False
@@ -110,7 +97,19 @@ test_enable = False
 test_file = 
 test_tags = 
 transient_age_limit = 1.0
+transient_memory_count_limit = False
 translate_modules = ['all']
 unaccent = False
 upgrade_path = 
-without_demo = False
+without_demo = True
+
+; ============================================
+; Queue Job Configuration (Required for OpenSPP)
+; ============================================
+[queue_job]
+channels = root:2
+; Database connection for job runner (uses main database settings if not specified)
+jobrunner_db_host = 
+jobrunner_db_port = 5432
+jobrunner_db_user = 
+jobrunner_db_password = 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,130 @@
+
+variable "PUSH_REGISTRY" {
+  default = "docker-push.acn.fr"
+}
+variable "REGISTRY" {
+  default = "docker.acn.fr"
+}
+variable "REPO" {
+  default = "openspp/openspp"
+}
+variable "IMAGE_NAME" {
+  default = "${REGISTRY}/${REPO}"
+}
+variable "PUSH_IMAGE_NAME" {
+  default = "${PUSH_REGISTRY}/${REPO}"
+}
+variable "IMAGE_TAG" {
+  default = "daily"
+}
+
+group "default" {
+  targets = [
+    # "openspp-debian-bookworm-slim",
+    # "openspp-debian-trixie-slim",
+    "openspp-ubuntu-24-04",
+    # "openspp-python-3-14-slim-bookworm",
+    # "openspp-python-3-13-slim-bookworm",
+    # "openspp-python-3-12-slim-bookworm"
+  ]
+}
+
+target "common" {
+  args = {
+    BUILD_DATE              = "$(date -u +\"%Y-%m-%dT%H:%M:%SZ\")"
+    DEBIAN_FRONTEND         = "noninteractive"
+    GID                     = "1001"
+    OPENSPP_VERSION         = "17.0.1-daily+odoo17.0-1"
+    PYTHONUNBUFFERED        = "1"
+    PYTHONDONTWRITEBYTECODE = "1"
+    TARGETARCH              = "amd64"
+    UID                     = "1001"
+    VCS_REF                 = "master"    
+    OPENSPP_LEFT_TO_RIGHT_LANGUAGE_SUPPORT = "false"
+  }
+}
+
+target "openspp-debian-bookworm-slim" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:debian-bookworm-slim-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:debian-bookworm-slim-${IMAGE_TAG}"
+  ]
+  args = {
+    BASE_IMAGE      = "debian:bookworm-slim"
+    
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "openspp-debian-trixie-slim" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:debian-trixie-slim-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:debian-trixie-slim-${IMAGE_TAG}"
+  ]
+  args = {
+    BASE_IMAGE      = "debian:trixie-slim"
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "openspp-ubuntu-24-04" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:ubuntu-24.04-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:ubuntu-24.04-${IMAGE_TAG}"
+  ]
+  args = {
+    BASE_IMAGE      = "ubuntu:24.04"
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "openspp-python-3-14-slim-bookworm" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:python-3-14-slim-bookworm-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:python-3-14-slim-bookworm-${IMAGE_TAG}"
+  ]
+  args = {
+    BASE_IMAGE      = "python:3.14-slim-bookworm"
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "openspp-python-3-13-slim-bookworm" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:python-3-13-slim-bookworm-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:python-3-13-slim-bookworm-${IMAGE_TAG}"
+  ]
+  args = {
+    BASE_IMAGE      = "python:3.13-slim-bookworm"
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "openspp-python-3-12-slim-bookworm" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "Dockerfile"
+  tags = [
+    "${IMAGE_NAME}:python-3-12-slim-bookworm-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:python-3-12-slim-bookworm-${IMAGE_TAG}"
+  ]
+  args = {
+    BASE_IMAGE      = "python:3.12-slim-bookworm"
+  }
+  platforms = ["linux/amd64"]
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Production Docker Compose Configuration for OpenSPP
 # This configuration includes:
 # - Security hardening

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,7 @@
 services:
   # PostgreSQL Database
   db:
-    image: postgres:15-alpine
+    image: postgis/postgis:15-3.5-alpine
     container_name: openspp_db_prod
     restart: always
     environment:
@@ -125,7 +125,7 @@ services:
       - openspp_data:/var/lib/openspp
       
       # Custom addons (read-only in production)
-      - ./custom-addons:/mnt/extra-addons:ro
+      - ./custom-addons:/mnt/extra-addons:ro,Z
       
       # Backup directory
       - ./backups:/backups
@@ -170,9 +170,9 @@ services:
     depends_on:
       - openspp
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/sites-enabled:/etc/nginx/sites-enabled:ro
-      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro,Z
+      - ./nginx/sites-enabled:/etc/nginx/sites-enabled:ro,Z
+      - ./nginx/ssl:/etc/nginx/ssl:ro,Z
       - nginx_cache:/var/cache/nginx
     ports:
       - "80:80"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@
 services:
   # PostgreSQL Database
   db:
-    image: postgres:15-alpine
+    image: postgis/postgis:15-3.5-alpine
     container_name: openspp-test-db
     environment:
       POSTGRES_USER: openspp
@@ -50,7 +50,7 @@ services:
       - "8072:8072"
     volumes:
       - test-openspp-data:/var/lib/openspp
-      - ./custom-addons:/mnt/extra-addons:ro
+      - ./custom-addons:/mnt/extra-addons:ro,Z
     networks:
       - openspp-test
     healthcheck:
@@ -84,7 +84,7 @@ services:
   #     - "8073:8072"
   #   volumes:
   #     - test-openspp-slim-data:/var/lib/openspp
-  #     - ./custom-addons:/mnt/extra-addons:ro
+  #     - ./custom-addons:/mnt/extra-addons:ro,Z
   #   networks:
   #     - openspp-test
   #   healthcheck:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,6 @@
 # ABOUTME: Docker Compose configuration for testing OpenSPP images
 # ABOUTME: Quick validation that built images work correctly with database
 
-version: '3.8'
-
 services:
   # PostgreSQL Database
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL Database
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # PostgreSQL Database
   db:
-    image: postgres:15-alpine
+    image: postgis/postgis:15-3.5-alpine
     container_name: openspp_db
     restart: unless-stopped
     environment:
@@ -11,7 +11,7 @@ services:
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=en_US.UTF-8"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./init-db:/docker-entrypoint-initdb.d:ro
+      - ./init-db:/docker-entrypoint-initdb.d:ro,Z
     # Port exposed only on localhost for debugging
     # Comment out for production or if not needed
     ports:
@@ -94,7 +94,7 @@ services:
       - openspp_data:/var/lib/openspp
       
       # Custom addons for development
-      - ./custom-addons:/mnt/extra-addons:ro
+      - ./custom-addons:/mnt/extra-addons:ro,Z
       
       # Configuration override (optional)
       # - ./config/custom-odoo.conf:/etc/openspp/odoo.conf:ro

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -91,12 +91,7 @@ wait_for_postgres() {
     
     # Use wait-for-psql.py if available, otherwise use psql
     if [ -f /usr/local/bin/wait-for-psql.py ]; then
-        python3 /usr/local/bin/wait-for-psql.py \
-            --db_host="${DB_HOST}" \
-            --db_port="${DB_PORT}" \
-            --db_user="${DB_USER}" \
-            --db_password="${DB_PASSWORD}" \
-            --timeout=30
+        python3 /usr/local/bin/wait-for-psql.py
     else
         local max_attempts=30
         local attempt=0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -177,10 +177,20 @@ main() {
                     ODOO_ADMIN_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
                     log_warn "Generated random admin password: $ODOO_ADMIN_PASSWORD"
                     log_warn "Set ODOO_ADMIN_PASSWORD environment variable to use a specific password"
-                    DB_ARGS+=("--admin_passwd=${ODOO_ADMIN_PASSWORD}")
+                    if grep -q "^; admin_passwd =" $ODOO_RC; then
+                      sed -i "s/^; admin_passwd = .*/admin_passwd = $ODOO_ADMIN_PASSWORD/" $ODOO_RC
+                    else
+                      echo "\nadmin_passwd = $ODOO_ADMIN_PASSWORD" >> $ODOO_RC
+                    fi
+                    # DB_ARGS+=("--admin_passwd=${ODOO_ADMIN_PASSWORD}")
                 fi
             else
-                DB_ARGS+=("--admin_passwd=${ODOO_ADMIN_PASSWORD}")
+              if grep -q "^; admin_passwd =" $ODOO_RC; then
+                sed -i "s/^; admin_passwd = .*/admin_passwd = $ODOO_ADMIN_PASSWORD/" $ODOO_RC
+              else
+                echo "\nadmin_passwd = $ODOO_ADMIN_PASSWORD" >> $ODOO_RC
+              fi
+              # DB_ARGS+=("--admin_passwd=${ODOO_ADMIN_PASSWORD}")
             fi
             
             # Add optional parameters from environment
@@ -254,7 +264,7 @@ main() {
                 ADDONS_PATH="${ADDONS_PATH},/mnt/extra-addons"
                 log_info "Extra addons detected at /mnt/extra-addons"
             fi
-            DB_ARGS+=("--addons_path=${ADDONS_PATH}")
+            DB_ARGS+=("--addons-path=${ADDONS_PATH}")
             
             # Log to stdout for container logs
             DB_ARGS+=("--logfile=-")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,7 +134,6 @@ main() {
       log_info "Using ODOO_ADMIN_PASSWORD from environment variable"
       # CRITICAL: Escape the password for safe use in sed (handles / \ &).
       SAFE_PASSWORD_ESCAPED=$(printf '%s' "$ODOO_ADMIN_PASSWORD" | sed -e 's/[\&]/\\&/g')
-      log_info "spe $SAFE_PASSWORD_ESCAPED"
       # If the line is commented out, uncomment and set the ENV value.
       if grep -q "^\s*; admin_passwd\s*=" "$ODOO_RC"; then
         sed -i "s|^\s*; admin_passwd\s*=.*|admin_passwd = $SAFE_PASSWORD_ESCAPED|g" "$ODOO_RC"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 # ABOUTME: Docker entrypoint for OpenSPP container
 # ABOUTME: Handles configuration, database wait, initialization, and proper signal handling
 
-set -e
+set -euo pipefail
 
 # Color output for better readability
 RED='\033[0;31m'
@@ -11,302 +11,227 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
+  echo -e "${GREEN}[INFO]${NC} $1"
 }
 
 log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
+  echo -e "${YELLOW}[WARN]${NC} $1"
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+  echo -e "${RED}[ERROR]${NC} $1"
 }
 
 # Support for Docker secrets via _FILE environment variables
 if [ -v PASSWORD_FILE ]; then
-    DB_PASSWORD="$(< $PASSWORD_FILE)"
+  DB_PASSWORD="$(<"$PASSWORD_FILE")"
 fi
 
 if [ -v DB_PASSWORD_FILE ]; then
-    DB_PASSWORD="$(< $DB_PASSWORD_FILE)"
+  DB_PASSWORD="$(<"$DB_PASSWORD_FILE")"
 fi
 
 if [ -v DB_USER_FILE ]; then
-    DB_USER="$(< $DB_USER_FILE)"
+  DB_USER="$(<"$DB_USER_FILE")"
 fi
 
 if [ -v DB_NAME_FILE ]; then
-    DB_NAME="$(< $DB_NAME_FILE)"
+  DB_NAME="$(<"$DB_NAME_FILE")"
 fi
 
 if [ -v ADMIN_PASSWORD_FILE ]; then
-    ODOO_ADMIN_PASSWORD="$(< $ADMIN_PASSWORD_FILE)"
+  ODOO_ADMIN_PASSWORD="$(<"$ADMIN_PASSWORD_FILE")"
 fi
 
 if [ -v ODOO_ADMIN_PASSWORD_FILE ]; then
-    ODOO_ADMIN_PASSWORD="$(< $ODOO_ADMIN_PASSWORD_FILE)"
+  ODOO_ADMIN_PASSWORD="$(<"$ODOO_ADMIN_PASSWORD_FILE")"
 fi
 
 # Set default database connection parameters
 # Support both new-style and legacy environment variables for compatibility
-: ${DB_HOST:=${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}}
-: ${DB_PORT:=${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}}
-: ${DB_USER:=${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='openspp'}}}}
-: ${DB_PASSWORD:=${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='openspp'}}}}
+: "${DB_HOST:=${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}}"
+: "${DB_PORT:=${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}}"
+: "${DB_USER:=${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='openspp'}}}}"
+: "${DB_PASSWORD:=${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='openspp'}}}}"
+: "${ADMIN_PASSWORD:=${ODOO_ADMIN_PASSWORD:='openspp'}}"
 
 # Function to check if parameter exists in config file
 check_config() {
-    local param="$1"
-    local value="$2"
-    
-    # Check if parameter exists in config file
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" 2>/dev/null; then
-        # Extract existing value from config
-        local config_value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" | cut -d "=" -f2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed 's/["\n\r]//g')
-        
-        # Only use config value if it's not "false" (which means unset in Odoo config)
-        if [ "${config_value}" != "false" ] && [ -n "${config_value}" ]; then
-            value="${config_value}"
-            log_info "Using ${param} from config file: ${value}"
-        else
-            log_info "Using ${param} from environment: ${value}"
-        fi
-    else
-        log_info "Using ${param} from environment: ${value}"
+  local param="$1"
+  local value="$2"
+
+  # Check if parameter exists in config file
+  if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" 2>/dev/null; then
+    # Extract existing value from config
+    local config_value
+    config_value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" | cut -d "=" -f2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed 's/["\n\r]//g')
+
+    # Only use config value if it's not "false" (which means unset in Odoo config)
+    if [ "${config_value}" != "false" ] && [ -n "${config_value}" ]; then
+      value="${config_value}"
     fi
-    
     # Add to arguments array
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
+  fi
 }
 
 # Function to wait for PostgreSQL
 wait_for_postgres() {
-    if [ "$SKIP_DB_WAIT" = "true" ]; then
-        log_warn "Skipping database wait (SKIP_DB_WAIT=true)"
-        return 0
+  if [[ -n "${SKIP_DB_WAIT:-}" ]]; then
+    if [[ "$SKIP_DB_WAIT" = "true" ]]; then
+      log_warn "Skipping database wait (SKIP_DB_WAIT=true)"
+      return 0
     fi
+  fi
 
-    log_info "Waiting for PostgreSQL at ${DB_HOST}:${DB_PORT}..."
-    
-    # Use wait-for-psql.py if available, otherwise use psql
-    if [ -f /usr/local/bin/wait-for-psql.py ]; then
-        python3 /usr/local/bin/wait-for-psql.py
-    else
-        local max_attempts=30
-        local attempt=0
-        
-        until PGPASSWORD="${DB_PASSWORD}" psql \
-            -h "${DB_HOST}" \
-            -p "${DB_PORT}" \
-            -U "${DB_USER}" \
-            -d "postgres" \
-            -c '\q' 2>/dev/null; do
-            
-            attempt=$((attempt + 1))
-            if [ $attempt -eq $max_attempts ]; then
-                log_error "PostgreSQL did not become ready in time"
-                exit 1
-            fi
-            
-            log_info "PostgreSQL is unavailable (attempt $attempt/$max_attempts) - sleeping"
-            sleep 2
-        done
-    fi
-    
-    log_info "PostgreSQL is ready!"
-}
-
-# Function to handle file permissions
-fix_permissions() {
-    if [ "$(id -u)" = "0" ]; then
-        log_info "Running as root, fixing permissions..."
-        
-        # Fix ownership for volumes
-        chown -R openspp:openspp /var/lib/openspp || true
-        chown -R openspp:openspp /mnt/extra-addons || true
-        
-        # Switch to openspp user using gosu
-        log_info "Switching to openspp user..."
-        exec gosu openspp "$0" "$@"
-    fi
+  log_info "Waiting for PostgreSQL at ${DB_HOST}:${DB_PORT}..."
+  python3 /usr/local/bin/wait-for-psql.py
 }
 
 # Main entrypoint logic
 main() {
-    # Initialize arrays for Odoo arguments
-    declare -a DB_ARGS=()
-    
-    # Set config file path
-    ODOO_RC=${ODOO_RC:-/etc/openspp/odoo.conf}
-    
-    # Fix permissions if running as root
-    fix_permissions "$@"
-    
-    # Handle different command types
-    case "$1" in
-        -- | odoo | openspp-server)
-            shift || true
-            
-            # Special case for scaffold command - doesn't need database
-            if [[ "$1" == "scaffold" ]]; then
-                exec /opt/openspp/venv/bin/python /opt/openspp/odoo-bin "$@"
-            fi
-            
-            # Wait for database
-            wait_for_postgres
-            
-            # Build database arguments from config or environment
-            check_config "db_host" "$DB_HOST"
-            check_config "db_port" "$DB_PORT"
-            check_config "db_user" "$DB_USER"
-            check_config "db_password" "$DB_PASSWORD"
-            
-            # Set database name if specified
-            if [ -n "${DB_NAME}" ] && [ "${DB_NAME}" != "false" ]; then
-                DB_ARGS+=("--database=${DB_NAME}")
-            fi
-            
-            # Admin password handling
-            if [ -z "$ODOO_ADMIN_PASSWORD" ]; then
-                # Check if admin_passwd is set in config
-                if grep -q -E "^\s*admin_passwd\s*=" "$ODOO_RC" 2>/dev/null; then
-                    log_info "Using admin_passwd from config file"
-                else
-                    # Generate secure random password if not set
-                    ODOO_ADMIN_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
-                    log_warn "Generated random admin password: $ODOO_ADMIN_PASSWORD"
-                    log_warn "Set ODOO_ADMIN_PASSWORD environment variable to use a specific password"
-                    if grep -q "^; admin_passwd =" $ODOO_RC; then
-                      sed -i "s/^; admin_passwd = .*/admin_passwd = $ODOO_ADMIN_PASSWORD/" $ODOO_RC
-                    else
-                      echo "\nadmin_passwd = $ODOO_ADMIN_PASSWORD" >> $ODOO_RC
-                    fi
-                    # DB_ARGS+=("--admin_passwd=${ODOO_ADMIN_PASSWORD}")
-                fi
-            else
-              if grep -q "^; admin_passwd =" $ODOO_RC; then
-                sed -i "s/^; admin_passwd = .*/admin_passwd = $ODOO_ADMIN_PASSWORD/" $ODOO_RC
-              else
-                echo "\nadmin_passwd = $ODOO_ADMIN_PASSWORD" >> $ODOO_RC
-              fi
-              # DB_ARGS+=("--admin_passwd=${ODOO_ADMIN_PASSWORD}")
-            fi
-            
-            # Add optional parameters from environment
-            [ -n "$ODOO_LIST_DB" ] && DB_ARGS+=("--list_db=${ODOO_LIST_DB}")
-            [ -n "$ODOO_LOG_LEVEL" ] && DB_ARGS+=("--log_level=${ODOO_LOG_LEVEL}")
-            [ -n "$ODOO_WORKERS" ] && DB_ARGS+=("--workers=${ODOO_WORKERS}")
-            [ -n "$ODOO_MAX_CRON_THREADS" ] && DB_ARGS+=("--max_cron_threads=${ODOO_MAX_CRON_THREADS}")
-            [ -n "$ODOO_PROXY_MODE" ] && DB_ARGS+=("--proxy_mode=${ODOO_PROXY_MODE}")
-            [ -n "$ODOO_WITHOUT_DEMO" ] && DB_ARGS+=("--without-demo=all")
-            
-            # Database initialization (first run)
-            if [ "$INIT_DATABASE" = "true" ]; then
-                log_info "Initializing database with base modules..."
-                
-                # Create database if it doesn't exist
-                if [ -n "${DB_NAME}" ]; then
-                    PGPASSWORD="${DB_PASSWORD}" createdb \
-                        -h "${DB_HOST}" \
-                        -p "${DB_PORT}" \
-                        -U "${DB_USER}" \
-                        "${DB_NAME}" 2>/dev/null || true
-                fi
-                
-                # Initialize with base module
-                /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
-                    "${DB_ARGS[@]}" \
-                    --init=base \
-                    --stop-after-init
-                
-                log_info "Database initialization complete"
-                
-                # CRITICAL: Install queue_job module for OpenSPP
-                if [ "$INSTALL_QUEUE_JOB" != "false" ]; then
-                    log_info "Installing queue_job module (required for OpenSPP)..."
-                    /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
-                        "${DB_ARGS[@]}" \
-                        --init=queue_job \
-                        --stop-after-init
-                    log_info "queue_job module installed - restart required for job runner to start"
-                fi
-            fi
-            
-            # Module installation
-            if [ -n "$INSTALL_MODULES" ]; then
-                log_info "Installing modules: $INSTALL_MODULES"
-                /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
-                    "${DB_ARGS[@]}" \
-                    --init="$INSTALL_MODULES" \
-                    --stop-after-init
-                log_info "Module installation complete"
-            fi
-            
-            # Module updates
-            if [ -n "$UPDATE_MODULES" ]; then
-                log_info "Updating modules: $UPDATE_MODULES"
-                DB_ARGS+=("--update=$UPDATE_MODULES")
-            fi
-            
-            # Development mode
-            if [ "$ODOO_DEV_MODE" = "true" ]; then
-                log_warn "Enabling development mode..."
-                DB_ARGS+=("--dev=all")
-                # Override workers for development
-                DB_ARGS+=("--workers=0")
-                log_warn "Workers set to 0 for development mode - queue_job will NOT function!"
-            fi
-            
-            # Handle addons path
-            ADDONS_PATH="/opt/openspp/addons"
-            if [ -d "/mnt/extra-addons" ] && [ "$(ls -A /mnt/extra-addons 2>/dev/null)" ]; then
-                ADDONS_PATH="${ADDONS_PATH},/mnt/extra-addons"
-                log_info "Extra addons detected at /mnt/extra-addons"
-            fi
-            DB_ARGS+=("--addons-path=${ADDONS_PATH}")
-            
-            # Log to stdout for container logs
-            DB_ARGS+=("--logfile=-")
-            
-            # Check workers configuration for queue_job
-            WORKERS_COUNT=$(echo "${ODOO_WORKERS:-2}" | grep -o '[0-9]*')
-            if [ "$WORKERS_COUNT" -eq 0 ] && [ "$ODOO_DEV_MODE" != "true" ]; then
-                log_warn "================================================"
-                log_warn "WARNING: workers=0 detected in production mode!"
-                log_warn "Queue Job async processing will NOT work!"
-                log_warn "Set ODOO_WORKERS to at least 2 for production"
-                log_warn "================================================"
-            fi
-            
-            log_info "Starting OpenSPP server..."
-            # Note: Database credentials may be visible in process list when passed as arguments
-            # This is a known limitation when using command-line arguments
-            # Consider using mounted config files for highly sensitive environments
-            log_info "Command: odoo-bin ${DB_ARGS[*]} $*"
-            
-            # Execute OpenSPP
-            exec /opt/openspp/venv/bin/python /opt/openspp/odoo-bin "${DB_ARGS[@]}" "$@"
-            ;;
-            
-        -*)
-            # Odoo command with flags
-            wait_for_postgres
-            
-            # Build database arguments
-            check_config "db_host" "$DB_HOST"
-            check_config "db_port" "$DB_PORT"
-            check_config "db_user" "$DB_USER"
-            check_config "db_password" "$DB_PASSWORD"
-            
-            exec /opt/openspp/venv/bin/python /opt/openspp/odoo-bin "$@" "${DB_ARGS[@]}"
-            ;;
-            
-        *)
-            # Custom command - execute directly
-            exec "$@"
-            ;;
-    esac
+  # Initialize arrays for Odoo arguments
+  declare -a DB_ARGS=()
+
+  # Set config file path
+  ODOO_RC=${ODOO_RC:-/etc/openspp/odoo.conf}
+
+  # Handle different command types
+  case "$1" in
+  -- | odoo | openspp-server)
+    shift || true
+
+    # Special case for scaffold command - doesn't need database
+    if [[ -n "${1:-}" ]]; then # Check if $1 is set and not empty
+      if [[ "$1" == "scaffold" ]]; then
+        exec /opt/openspp/venv/bin/python /opt/openspp/odoo-bin "$@"
+      fi
+    fi
+
+    # Wait for database
+    wait_for_postgres
+
+    # Build database arguments from config or environment
+    check_config "db_host" "$DB_HOST"
+    check_config "db_port" "$DB_PORT"
+    check_config "db_user" "$DB_USER"
+    check_config "db_password" "$DB_PASSWORD"
+
+    # Set database name if specified
+    if [ -n "${DB_NAME}" ] && [ "${DB_NAME}" != "false" ]; then
+      DB_ARGS+=("--database=${DB_NAME}")
+    fi
+
+    # Admin password handling
+    if [ -z "$ODOO_ADMIN_PASSWORD" ]; then
+      # Check if admin_passwd is set in config
+      if grep -q -E "^\s*admin_passwd\s*=" "$ODOO_RC" 2>/dev/null; then
+        log_info "Using admin_passwd from config file"
+      else
+        # Generate secure random password if not set
+        ODOO_ADMIN_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
+        log_warn "Set ODOO_ADMIN_PASSWORD environment variable to use a specific password"
+        # Insert admin_passwd after the [options] section header
+        sed -i "s/^; admin_passwd = /admin passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+      fi
+    else
+      if grep -q "^; admin_passwd =" "$ODOO_RC"; then
+        sed -i "s/^; admin_passwd = /admin passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+      else
+        sed -i "s/^; admin_passwd = /admin passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+      fi
+    fi
+
+    # Database initialization (first run)
+    if [ "${INIT_DATABASE,,}" = "true" ]; then
+      log_info "Initializing database with base modules..."
+
+      # Initialize with base module
+      /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
+        "${DB_ARGS[@]}" \
+        --init=base \
+        --stop-after-init
+
+      log_info "Database initialization complete"
+
+      # CRITICAL: Install queue_job module for OpenSPP
+      log_info "Installing queue_job module (required for OpenSPP)..."
+      /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
+        "${DB_ARGS[@]}" \
+        --init=queue_job \
+        --stop-after-init
+      log_info "queue_job module installed - restart required for job runner to start"
+    fi
+
+    # Module installation
+    if [ -n "${INSTALL_MODULES}" ]; then
+      log_info "Installing modules: $INSTALL_MODULES"
+      /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
+        "${DB_ARGS[@]}" \
+        --init="$INSTALL_MODULES" \
+        --stop-after-init
+      log_info "Module installation complete"
+    fi
+
+    # Module updates
+    if [ -n "${UPDATE_MODULES}" ]; then
+      log_info "Updating modules: $UPDATE_MODULES"
+      DB_ARGS+=("--update=$UPDATE_MODULES")
+    fi
+
+    # Development mode
+    if [ "${ODOO_DEV_MODE,,}" = "true" ]; then
+      log_warn "Enabling development mode..."
+      DB_ARGS+=("--dev=all")
+      # Override workers for development
+      DB_ARGS+=("--workers=0")
+      log_warn "Workers set to 0 for development mode - queue_job will NOT function!"
+    fi
+
+    # Handle addons path
+    ADDONS_PATH="/opt/openspp/addons"
+    if [ -d "/mnt/extra-addons" ] && [ "$(ls -A /mnt/extra-addons 2>/dev/null)" ]; then
+      ADDONS_PATH="${ADDONS_PATH},/mnt/extra-addons"
+      log_info "Extra addons detected at /mnt/extra-addons"
+    fi
+    DB_ARGS+=("--addons-path=${ADDONS_PATH}")
+
+    # Check workers configuration for queue_job
+    WORKERS_COUNT=$(echo "${ODOO_WORKERS:-2}" | grep -o '[0-9]*')
+    if [ "$WORKERS_COUNT" -eq 0 ] && [ "$ODOO_DEV_MODE" != "true" ]; then
+      log_warn "================================================"
+      log_warn "WARNING: workers=0 detected in production mode!"
+      log_warn "Queue Job async processing will NOT work!"
+      log_warn "Set ODOO_WORKERS to at least 2 for production"
+      log_warn "================================================"
+    fi
+
+    log_info "Starting OpenSPP server..."
+
+    # Execute OpenSPP
+    # exec /opt/openspp/venv/bin/python /opt/openspp/odoo-bin "${DB_ARGS[@]}" "$@"
+    exec /opt/openspp/odoo-bin "${DB_ARGS[@]}" "$@"
+    ;;
+
+  -*)
+    # Odoo command with flags
+    wait_for_postgres
+
+    # Build database arguments
+    check_config "db_host" "$DB_HOST"
+    check_config "db_port" "$DB_PORT"
+    check_config "db_user" "$DB_USER"
+    check_config "db_password" "$DB_PASSWORD"
+
+    exec /opt/openspp/venv/bin/python /opt/openspp/odoo-bin "$@" "${DB_ARGS[@]}"
+    ;;
+
+  *)
+    # Custom command - execute directly
+    exec "$@"
+    ;;
+  esac
 }
 
 # Run main function

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -132,14 +132,18 @@ main() {
     # 2. Check if ODOO_ADMIN_PASSWORD is set in the environment.
     elif [ -n "$ODOO_ADMIN_PASSWORD" ]; then
       log_info "Using ODOO_ADMIN_PASSWORD from environment variable"
+      # CRITICAL: Escape the password for safe use in sed (handles / \ &).
+      SAFE_PASSWORD_ESCAPED=$(printf '%s' "$ODOO_ADMIN_PASSWORD" | sed -e 's/[\&]/\\&/g')
+      DELIMITER=$(echo "$SAFE_PASSWORD_ESCAPED" | tr -d '[|:=_~]' | head -c 1)
+      if [ -z "$DELIMITER" ]; then
+        DELIMITER='\x01'
+      fi
       # If the line is commented out, uncomment and set the ENV value.
       if grep -q "^\s*; admin_passwd\s*=" "$ODOO_RC"; then
-        sed -i "s/^\s*; admin_passwd\s*=.*/admin_passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
-      # If the admin_passwd line is missing entirely, insert it after [options].
+        sed -i "s${DELIMITER}^\s*; admin_passwd\s*=.*${DELIMITER}admin_passwd = $SAFE_PASSWORD_ESCAPED${DELIMITER}g" "$ODOO_RC"      # If the admin_passwd line is missing entirely, insert it after [options].
       else
         log_info "admin_passwd line missing. Inserting ODOO_ADMIN_PASSWORD from ENV."
-        sed -i "/^\[options\]/a admin_passwd = $ODOO_ADMIN_PASSWORD" "$ODOO_RC"
-      fi
+        sed -i "/^\[options\]/a admin_passwd = $SAFE_PASSWORD_ESCAPED" "$ODOO_RC"      fi
     # If no hardcoded or environment password is found, generate a new secure random password.
     else
       # Generate secure random password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -124,22 +124,34 @@ main() {
     fi
 
     # Admin password handling
-    if [ -z "$ODOO_ADMIN_PASSWORD" ]; then
-      # Check if admin_passwd is set in config
-      if grep -q -E "^\s*admin_passwd\s*=" "$ODOO_RC" 2>/dev/null; then
-        log_info "Using admin_passwd from config file"
+
+    # 1. Check for HARDCODED (uncommented) admin_passwd in the config file.
+    #    This value takes precedence over environment variables.
+    if grep -q -E "^\s*admin_passwd\s*=" "$ODOO_RC" 2>/dev/null; then
+      log_info "Using admin_passwd from config file"
+    # 2. Check if ODOO_ADMIN_PASSWORD is set in the environment.
+    elif [ -n "$ODOO_ADMIN_PASSWORD" ]; then
+      log_info "Using ODOO_ADMIN_PASSWORD from environment variable"
+      # If the line is commented out, uncomment and set the ENV value.
+      if grep -q "^\s*; admin_passwd\s*=" "$ODOO_RC"; then
+        sed -i "s/^\s*; admin_passwd\s*=.*/admin_passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+      # If the admin_passwd line is missing entirely, insert it after [options].
       else
-        # Generate secure random password if not set
-        ODOO_ADMIN_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
-        log_warn "Set ODOO_ADMIN_PASSWORD environment variable to use a specific password"
-        # Insert admin_passwd after the [options] section header
-        sed -i "s/^; admin_passwd = /admin passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+        log_info "admin_passwd line missing. Inserting ODOO_ADMIN_PASSWORD from ENV."
+        sed -i "/^\[options\]/a admin_passwd = $ODOO_ADMIN_PASSWORD" "$ODOO_RC"
       fi
+    # If no hardcoded or environment password is found, generate a new secure random password.
     else
-      if grep -q "^; admin_passwd =" "$ODOO_RC"; then
-        sed -i "s/^; admin_passwd = /admin passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+      # Generate secure random password
+      ODOO_ADMIN_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-25)
+      log_warn "Set ODOO_ADMIN_PASSWORD environment variable to use a specific password"
+      # If the line is commented out, uncomment and set the ENV value.
+      if grep -q "^\s*; admin_passwd\s*=" "$ODOO_RC"; then
+        sed -i "s/^\s*; admin_passwd\s*=.*/admin_passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+      # If the admin_passwd line is missing entirely, insert it after [options].      
       else
-        sed -i "s/^; admin_passwd = /admin passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
+        log_info "admin_passwd line missing. Inserting generated password."
+        sed -i "/^\[options\]/a admin_passwd = $ODOO_ADMIN_PASSWORD" "$ODOO_RC"
       fi
     fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -134,16 +134,15 @@ main() {
       log_info "Using ODOO_ADMIN_PASSWORD from environment variable"
       # CRITICAL: Escape the password for safe use in sed (handles / \ &).
       SAFE_PASSWORD_ESCAPED=$(printf '%s' "$ODOO_ADMIN_PASSWORD" | sed -e 's/[\&]/\\&/g')
-      DELIMITER=$(echo "$SAFE_PASSWORD_ESCAPED" | tr -d '[|:=_~]' | head -c 1)
-      if [ -z "$DELIMITER" ]; then
-        DELIMITER='\x01'
-      fi
+      log_info "spe $SAFE_PASSWORD_ESCAPED"
       # If the line is commented out, uncomment and set the ENV value.
       if grep -q "^\s*; admin_passwd\s*=" "$ODOO_RC"; then
-        sed -i "s${DELIMITER}^\s*; admin_passwd\s*=.*${DELIMITER}admin_passwd = $SAFE_PASSWORD_ESCAPED${DELIMITER}g" "$ODOO_RC"      # If the admin_passwd line is missing entirely, insert it after [options].
+        sed -i "s|^\s*; admin_passwd\s*=.*|admin_passwd = $SAFE_PASSWORD_ESCAPED|g" "$ODOO_RC"
+      # If the admin_passwd line is missing entirely, insert it after [options].
       else
         log_info "admin_passwd line missing. Inserting ODOO_ADMIN_PASSWORD from ENV."
-        sed -i "/^\[options\]/a admin_passwd = $SAFE_PASSWORD_ESCAPED" "$ODOO_RC"      fi
+        sed -i "/^\[options\]/a admin_passwd = $SAFE_PASSWORD_ESCAPED" "$ODOO_RC"
+      fi
     # If no hardcoded or environment password is found, generate a new secure random password.
     else
       # Generate secure random password
@@ -152,7 +151,7 @@ main() {
       # If the line is commented out, uncomment and set the ENV value.
       if grep -q "^\s*; admin_passwd\s*=" "$ODOO_RC"; then
         sed -i "s/^\s*; admin_passwd\s*=.*/admin_passwd = $ODOO_ADMIN_PASSWORD/g" "$ODOO_RC"
-      # If the admin_passwd line is missing entirely, insert it after [options].      
+      # If the admin_passwd line is missing entirely, insert it after [options].
       else
         log_info "admin_passwd line missing. Inserting generated password."
         sed -i "/^\[options\]/a admin_passwd = $ODOO_ADMIN_PASSWORD" "$ODOO_RC"

--- a/wait-for-psql.py
+++ b/wait-for-psql.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # ABOUTME: Python script to wait for PostgreSQL availability
-# ABOUTME: Used as fallback when psql client is not available
 
 import os
 import sys

--- a/wait-for-psql.py
+++ b/wait-for-psql.py
@@ -15,7 +15,7 @@ def wait_for_psql():
     db_password = os.environ.get('DB_PASSWORD', 'openspp')
     db_name = os.environ.get('DB_NAME', 'postgres')
     
-    max_attempts = 60
+    max_attempts = 24
     attempt = 0
     
     print(f"Waiting for PostgreSQL at {db_host}:{db_port}...")
@@ -36,7 +36,7 @@ def wait_for_psql():
         except OperationalError as e:
             attempt += 1
             print(f"PostgreSQL is unavailable (attempt {attempt}/{max_attempts}) - sleeping")
-            time.sleep(2)
+            time.sleep(5)
     
     print("PostgreSQL did not become ready in time", file=sys.stderr)
     return 1


### PR DESCRIPTION
The issues were preventing OpenSPP from starting when using the `docker run` commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Docker build and runtime to install OpenSPP from APT with verified keys, add wkhtmltopdf, improve entrypoint/config handling, and update compose, tooling, and docs.
> 
> - **Docker images**:
>   - Multi-stage builds with `BASE_IMAGE` arg; new `openspp_installer` and `wkhtmltopdf_installer` stages (downloads `.deb` with SHA256 verification).
>   - Configure APT repo with GPG key verification; install `openspp-17-daily`.
>   - Final images set labels/env dynamically, create non-root user, copy from installer stages; dynamic base labels.
> - **Entrypoint & config**:
>   - Rewrites `docker-entrypoint.sh` to support secrets, safer admin password handling (config edit), DB wait via `wait-for-psql.py`, init flow (auto-install `queue_job`), dev mode/workers checks, and `--addons-path` usage.
>   - Updates `config/odoo.conf` (use `gevent_port`, `without_demo = True`, add/transplant `[queue_job]`, memory keys cleanup).
> - **Compose files**:
>   - Switch DB images to PostGIS variants; add `:Z` mount flags; healthchecks/resources; minor network/volume tweaks.
> - **Build tooling**:
>   - Add `docker-bake.hcl`; Makefile switches to `buildx`, adds `bake`, info/prod-check, colored output; add `analyze-layers.sh`.
>   - Add `ci-docker-push.sh` (explicit Nexus login/push) and Nexus/Woodpecker setup/troubleshooting docs.
> - **Docs**:
>   - Revamp README, testing guide, and GitHub Actions setup with clearer steps, compose examples, and registry details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3993dbb18057f1c005cf3d5427dee58fedb0dc88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->