### PR TITLE
Fix/markdown and compose

### DIFF
--- a/GITHUB_ACTIONS_SETUP.md
+++ b/GITHUB_ACTIONS_SETUP.md
@@ -9,10 +9,12 @@ This repository uses GitHub Actions for CI/CD to build and push OpenSPP Docker i
 Configure the following secrets in your GitHub repository settings:
 
 ### Registry Authentication
+
 - `NEXUS_USERNAME`: Nexus registry username (e.g., `admin`)
 - `NEXUS_PASSWORD`: Nexus registry password
 
 ### Optional Notifications
+
 - `SLACK_WEBHOOK`: Slack webhook URL for build notifications (optional)
 
 ### Setting Secrets
@@ -31,12 +33,14 @@ Configure the following secrets in your GitHub repository settings:
 ### 1. Docker Build and Push (`docker-build.yml`)
 
 **Triggers:**
+
 - Push to main, master, develop, or release/* branches
 - Pull requests to main, master, or develop
 - Git tags (v*, semantic versioning)
 - Manual workflow dispatch
 
 **Actions:**
+
 - Builds Ubuntu 24.04 and Debian slim Docker images
 - **Platform:** linux/amd64 only (no ARM support)
 - Pushes to Nexus registry (`docker-push.acn.fr`)
@@ -45,6 +49,7 @@ Configure the following secrets in your GitHub repository settings:
 - Updates Kubernetes manifests on tag releases
 
 **Image Tags:**
+
 - `latest` / `latest-slim` - Latest from main branch
 - `daily` / `daily-slim` - Daily builds from main branch
 - `v1.0.0` / `v1.0.0-slim` - Version tags
@@ -54,12 +59,14 @@ Configure the following secrets in your GitHub repository settings:
 ### 2. Security Scan (`security-scan.yml`)
 
 **Triggers:**
+
 - Push to main branches
 - Pull requests
 - Daily at 2 AM UTC
 - Manual workflow dispatch
 
 **Actions:**
+
 - Trivy vulnerability scanning
 - Hadolint Dockerfile linting
 - OWASP dependency checking
@@ -78,6 +85,7 @@ Configure the following secrets in your GitHub repository settings:
 ### Automatic Builds
 
 Images are automatically built and pushed when:
+
 - Pushing to main/master/develop branches
 - Creating a new release tag
 - Changes are tested (but not pushed) on pull requests
@@ -85,12 +93,14 @@ Images are automatically built and pushed when:
 ## Registry Information
 
 ### Push Registry (Authentication Required)
-```
+
+``` text
 docker-push.acn.fr/openspp/openspp
 ```
 
 ### Public Registry (Anonymous Pull)
-```
+
+``` text
 docker.acn.fr/openspp/openspp
 ```
 
@@ -115,6 +125,7 @@ docker pull docker.acn.fr/openspp/openspp:v1.0.0-slim
 ## Build Status
 
 You can view build status in the **Actions** tab of your repository. Each workflow run shows:
+
 - Build logs
 - Test results
 - Security scan findings
@@ -125,8 +136,10 @@ You can view build status in the **Actions** tab of your repository. Each workfl
 ### Authentication Failures
 
 If builds fail with authentication errors:
+
 1. Verify `NEXUS_USERNAME` and `NEXUS_PASSWORD` secrets are set correctly
 2. Test credentials locally:
+
    ```bash
    docker login docker-push.acn.fr -u <username>
    ```
@@ -142,6 +155,7 @@ If builds fail with authentication errors:
 ### Security Scan Issues
 
 Security scans may find vulnerabilities. Check:
+
 1. **Security** tab for detailed reports
 2. Trivy results in workflow logs
 3. Consider updating base images or packages
@@ -152,13 +166,14 @@ Security scans may find vulnerabilities. Check:
 - **Base Images:**
   - Ubuntu: `ubuntu:24.04`
   - Slim: `debian:bookworm-slim`
-- **OpenSPP Source:** APT repository at https://builds.acn.fr/repository/apt-openspp-daily/
+- **OpenSPP Source:** APT repository at [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 
 ## Monitoring
 
 ### Build Notifications
 
 If `SLACK_WEBHOOK` is configured, you'll receive notifications for:
+
 - Successful builds
 - Failed builds
 - Security scan results
@@ -166,6 +181,7 @@ If `SLACK_WEBHOOK` is configured, you'll receive notifications for:
 ### GitHub Notifications
 
 Enable GitHub notifications to receive updates about:
+
 - Workflow failures
 - Security alerts
 - Pull request checks
@@ -181,6 +197,7 @@ Enable GitHub notifications to receive updates about:
 ## Support
 
 For issues with:
+
 - **GitHub Actions:** Check [GitHub Actions documentation](https://docs.github.com/actions)
 - **Docker builds:** Review Dockerfile and build logs
 - **Nexus registry:** Contact your Nexus administrator

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -2,14 +2,16 @@
 
 Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 
+``` text
 > **Note:** Configuration updated to install directly from OpenSPP APT repository instead of copying local deb files.
 > 
 > **Repository:** https://builds.acn.fr/repository/apt-openspp-daily/
 > **Package:** `openspp-17-daily`
+```
 
 ## Key Improvements Implemented
 
-### APT Repository Integration (Latest Update):
+### APT Repository Integration (Latest Update)
 
 1. **Direct APT Installation**
    - Removed dependency on local deb file copying
@@ -20,8 +22,8 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 2. **Repository Configuration**
    - Uses signed-by GPG key for secure APT repository
    - Supports both Ubuntu (noble) and Debian (bookworm) distributions
-   - Repository URL: https://builds.acn.fr/repository/apt-openspp-daily/
-   - GPG Key: https://builds.acn.fr/repository/apt-keys/openspp/public.key
+   - Repository URL: [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
+   - GPG Key: [https://builds.acn.fr/repository/apt-keys/openspp/public.key](https://builds.acn.fr/repository/apt-keys/openspp/public.key)
 
 3. **Benefits**
    - Always get latest daily build automatically
@@ -30,7 +32,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Simplified build process
    - Better integration with CI/CD pipelines
 
-### From Official Odoo Docker:
+### From Official Odoo Docker
 
 1. **Enhanced Python Dependencies**
    - Added Python packages for better compatibility: `python3-magic`, `python3-num2words`, `python3-odf`, `python3-pdfminer`, `python3-phonenumbers`, `python3-pyldap`, `python3-qrcode`, `python3-renderpm`, `python3-slugify`, `python3-vobject`, `python3-watchdog`, `python3-xlrd`, `python3-xlwt`
@@ -51,7 +53,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Respect config file values when set
    - More flexible configuration management
 
-### From OpenSPP Installation Guide:
+### From OpenSPP Installation Guide
 
 1. **Queue Job Configuration (CRITICAL)**
    - Set default workers to 2 (was 0)
@@ -75,7 +77,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Worker configuration for production vs development
    - Clear documentation about performance tuning
 
-## Files Updated:
+## Files Updated
 
 1. **Dockerfile**
    - Added Python dependencies and rtlcss
@@ -107,26 +109,29 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
    - Production readiness checks
    - Database initialization helpers
 
-## Critical Requirements for OpenSPP:
+## Critical Requirements for OpenSPP
 
 ### Queue Job Module
+
 - **MUST** have workers > 0 (minimum 2 for production)
 - **MUST** include queue_job in server_wide_modules
 - **MUST** restart after installing queue_job module
 - Development mode (workers=0) disables async operations
 
-### Security in Production:
+### Security in Production
+
 - Set `list_db = False`
 - Use strong admin password
 - Enable `proxy_mode` when behind reverse proxy
 - Use Docker secrets for sensitive data
 
-### Performance:
+### Performance
+
 - Workers: 1 per CPU core (minimum 2)
 - Adjust memory limits based on available RAM
 - Use Redis for caching (separate container)
 
-## Testing Checklist:
+## Testing Checklist
 
 - [ ] Build standard image
 - [ ] Build slim image  
@@ -139,7 +144,7 @@ Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 - [ ] Check logs output
 - [ ] Validate production readiness
 
-## Next Steps:
+## Next Steps
 
 1. Run `make build-all` to build images (pulls from APT repository)
 2. Run `make run` to start development environment

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -2,12 +2,11 @@
 
 Based on review of official Odoo Docker setup and OpenSPP Installation Guide.
 
-``` text
-> **Note:** Configuration updated to install directly from OpenSPP APT repository instead of copying local deb files.
-> 
-> **Repository:** https://builds.acn.fr/repository/apt-openspp-daily/
+> [!NOTE]
+> Configuration updated to install directly from OpenSPP APT repository instead of copying local deb files.
+>
+> **Repository:** [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 > **Package:** `openspp-17-daily`
-```
 
 ## Key Improvements Implemented
 

--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,21 @@ COMPOSE_FILE ?= docker-compose.yml
 COMPOSE_PROD_FILE ?= docker-compose.prod.yml
 
 # Colors for output
-RED := \033[0;31m
-GREEN := \033[0;32m
+RED := \033[1;31m
+GREEN := \033[1;32m
 YELLOW := \033[1;33m
 NC := \033[0m # No Color
 
 help: ## Show this help message
-	@echo "$(GREEN)OpenSPP Docker Management$(NC)"
+	@echo -e "$(GREEN)OpenSPP Docker Management$(NC)"
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(YELLOW)%-15s$(NC) %s\n", $$1, $$2}'
 
 build: ## Build the standard Ubuntu-based image
-	@echo "$(GREEN)Building OpenSPP image (Ubuntu 24.04)...$(NC)"
-	@echo "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
+	@echo -e "$(GREEN)Building OpenSPP image (Ubuntu 24.04)...$(NC)"
+	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
 	docker build \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
@@ -39,8 +39,8 @@ build: ## Build the standard Ubuntu-based image
 		-f Dockerfile .
 
 build-slim: ## Build the lightweight Debian-based image
-	@echo "$(GREEN)Building OpenSPP slim image (Debian bookworm)...$(NC)"
-	@echo "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
+	@echo -e "$(GREEN)Building OpenSPP slim image (Debian bookworm)...$(NC)"
+	@echo -e "$(YELLOW)Installing from APT repository: https://builds.acn.fr/repository/apt-openspp-daily$(NC)"
 	docker build \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
 		--build-arg VCS_REF=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") \
@@ -53,28 +53,28 @@ build-slim: ## Build the lightweight Debian-based image
 build-all: build build-slim ## Build both standard and slim images
 
 run: ## Start OpenSPP with docker-compose (development)
-	@echo "$(GREEN)Starting OpenSPP development environment...$(NC)"
+	@echo -e "$(GREEN)Starting OpenSPP development environment...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) up -d
-	@echo "$(GREEN)OpenSPP is starting at http://localhost:8069$(NC)"
-	@echo "$(YELLOW)Note: Workers are set to 2 for queue_job support$(NC)"
+	@echo -e "$(GREEN)OpenSPP is starting at http://localhost:8069$(NC)"
+	@echo -e "$(YELLOW)Note: Workers are set to 2 for queue_job support$(NC)"
 
 run-prod: ## Start OpenSPP with production configuration
-	@echo "$(GREEN)Starting OpenSPP production environment...$(NC)"
+	@echo -e "$(GREEN)Starting OpenSPP production environment...$(NC)"
 	docker-compose -f $(COMPOSE_PROD_FILE) up -d
-	@echo "$(GREEN)OpenSPP production is starting$(NC)"
+	@echo -e "$(GREEN)OpenSPP production is starting$(NC)"
 
 stop: ## Stop all OpenSPP containers
-	@echo "$(YELLOW)Stopping OpenSPP containers...$(NC)"
+	@echo -e "$(YELLOW)Stopping OpenSPP containers...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) down
 
 stop-prod: ## Stop production containers
-	@echo "$(YELLOW)Stopping OpenSPP production containers...$(NC)"
+	@echo -e "$(YELLOW)Stopping OpenSPP production containers...$(NC)"
 	docker-compose -f $(COMPOSE_PROD_FILE) down
 
 clean: ## Remove containers, volumes, and images
-	@echo "$(RED)Removing OpenSPP containers and volumes...$(NC)"
+	@echo -e "$(RED)Removing OpenSPP containers and volumes...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) down -v
-	@echo "$(RED)Removing OpenSPP images...$(NC)"
+	@echo -e "$(RED)Removing OpenSPP images...$(NC)"
 	docker rmi $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):latest || true
 	docker rmi $(IMAGE_NAME):$(IMAGE_TAG)-slim $(IMAGE_NAME):latest-slim || true
 
@@ -85,26 +85,26 @@ logs-all: ## View all container logs
 	docker-compose -f $(COMPOSE_FILE) logs -f
 
 shell: ## Open a shell in the OpenSPP container
-	@echo "$(GREEN)Opening shell in OpenSPP container...$(NC)"
+	@echo -e "$(GREEN)Opening shell in OpenSPP container...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec openspp /bin/bash
 
 shell-root: ## Open a root shell in the OpenSPP container
-	@echo "$(GREEN)Opening root shell in OpenSPP container...$(NC)"
+	@echo -e "$(GREEN)Opening root shell in OpenSPP container...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec -u root openspp /bin/bash
 
 db-shell: ## Open PostgreSQL shell
-	@echo "$(GREEN)Opening PostgreSQL shell...$(NC)"
+	@echo -e "$(GREEN)Opening PostgreSQL shell...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec db psql -U openspp openspp
 
 odoo-shell: ## Open Odoo Python shell
-	@echo "$(GREEN)Opening Odoo Python shell...$(NC)"
+	@echo -e "$(GREEN)Opening Odoo Python shell...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) exec openspp openspp-shell
 
 test: ## Run basic tests on the container
-	@echo "$(GREEN)Running container tests...$(NC)"
+	@echo -e "$(GREEN)Running container tests...$(NC)"
 	@echo "1. Testing image build..."
 	docker run --rm $(IMAGE_NAME):latest openspp-server --version
-	@echo "$(GREEN)✓ Version check passed$(NC)"
+	@echo -e "$(GREEN)✓ Version check passed$(NC)"
 	@echo ""
 	@echo "2. Testing health endpoint..."
 	docker-compose -f $(COMPOSE_FILE) up -d
@@ -113,63 +113,63 @@ test: ## Run basic tests on the container
 	@echo ""
 	@echo "3. Checking workers configuration..."
 	@docker-compose -f $(COMPOSE_FILE) exec openspp grep "workers" /etc/openspp/odoo.conf
-	@echo "$(GREEN)✓ Workers configuration checked$(NC)"
+	@echo -e "$(GREEN)✓ Workers configuration checked$(NC)"
 
 init-db: ## Initialize database with base modules
-	@echo "$(GREEN)Initializing OpenSPP database...$(NC)"
+	@echo -e "$(GREEN)Initializing OpenSPP database...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) run --rm \
 		-e INIT_DATABASE=true \
 		-e INSTALL_QUEUE_JOB=true \
 		openspp
-	@echo "$(GREEN)Database initialized. Restart required for queue_job.$(NC)"
+	@echo -e "$(GREEN)Database initialized. Restart required for queue_job.$(NC)"
 	@echo "Run: make restart"
 
 restart: ## Restart OpenSPP containers
-	@echo "$(YELLOW)Restarting OpenSPP containers...$(NC)"
+	@echo -e "$(YELLOW)Restarting OpenSPP containers...$(NC)"
 	docker-compose -f $(COMPOSE_FILE) restart
-	@echo "$(GREEN)OpenSPP restarted$(NC)"
+	@echo -e "$(GREEN)OpenSPP restarted$(NC)"
 
 install-modules: ## Install OpenSPP modules (set MODULES env var)
-	@echo "$(GREEN)Installing modules: $(MODULES)$(NC)"
+	@echo -e "$(GREEN)Installing modules: $(MODULES)$(NC)"
 	docker-compose -f $(COMPOSE_FILE) run --rm \
 		-e INSTALL_MODULES="$(MODULES)" \
 		openspp
-	@echo "$(GREEN)Modules installed$(NC)"
+	@echo -e "$(GREEN)Modules installed$(NC)"
 
 update-modules: ## Update OpenSPP modules (set MODULES env var)
-	@echo "$(GREEN)Updating modules: $(MODULES)$(NC)"
+	@echo -e "$(GREEN)Updating modules: $(MODULES)$(NC)"
 	docker-compose -f $(COMPOSE_FILE) run --rm \
 		-e UPDATE_MODULES="$(MODULES)" \
 		openspp
-	@echo "$(GREEN)Modules updated$(NC)"
+	@echo -e "$(GREEN)Modules updated$(NC)"
 
 backup: ## Backup database and filestore
-	@echo "$(GREEN)Creating backup...$(NC)"
+	@echo -e "$(GREEN)Creating backup...$(NC)"
 	@mkdir -p backups
 	@docker-compose -f $(COMPOSE_FILE) exec db pg_dump -U openspp openspp | gzip > backups/openspp_$(shell date +%Y%m%d_%H%M%S).sql.gz
 	@docker-compose -f $(COMPOSE_FILE) exec openspp tar -czf - /var/lib/openspp > backups/filestore_$(shell date +%Y%m%d_%H%M%S).tar.gz
-	@echo "$(GREEN)Backup completed in ./backups/$(NC)"
+	@echo -e "$(GREEN)Backup completed in ./backups/$(NC)"
 
 push: ## Push images to Nexus registry
-	@echo "$(GREEN)Pushing images to $(PUSH_REGISTRY)...$(NC)"
-	@echo "$(YELLOW)Note: Make sure you're logged in: docker login $(PUSH_REGISTRY)$(NC)"
+	@echo -e "$(GREEN)Pushing images to $(PUSH_REGISTRY)...$(NC)"
+	@echo -e "$(YELLOW)Note: Make sure you're logged in: docker login $(PUSH_REGISTRY)$(NC)"
 	docker push $(PUSH_IMAGE_NAME):$(IMAGE_TAG)
 	docker push $(PUSH_IMAGE_NAME):latest
 	docker push $(PUSH_IMAGE_NAME):$(IMAGE_TAG)-slim
 	docker push $(PUSH_IMAGE_NAME):latest-slim
-	@echo "$(GREEN)Images pushed successfully$(NC)"
-	@echo "$(GREEN)Images available for public access at:$(NC)"
+	@echo -e "$(GREEN)Images pushed successfully$(NC)"
+	@echo -e "$(GREEN)Images available for public access at:$(NC)"
 	@echo "  $(IMAGE_NAME):$(IMAGE_TAG)"
 	@echo "  $(IMAGE_NAME):$(IMAGE_TAG)-slim"
 
 scan: ## Security scan with Trivy
-	@echo "$(GREEN)Scanning images for vulnerabilities...$(NC)"
+	@echo -e "$(GREEN)Scanning images for vulnerabilities...$(NC)"
 	@which trivy > /dev/null || (echo "$(RED)Trivy not installed. Install from: https://github.com/aquasecurity/trivy$(NC)" && exit 1)
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest-slim
 
 info: ## Show environment information
-	@echo "$(GREEN)OpenSPP Docker Environment Information$(NC)"
+	@echo -e "$(GREEN)OpenSPP Docker Environment Information$(NC)"
 	@echo "Image Tag: $(IMAGE_TAG)"
 	@echo "Public Registry: $(REGISTRY)"
 	@echo "Push Registry: $(PUSH_REGISTRY)"
@@ -178,21 +178,21 @@ info: ## Show environment information
 	@echo "Push Image: $(PUSH_IMAGE_NAME)"
 	@echo "APT Repository: https://builds.acn.fr/repository/apt-openspp-daily"
 	@echo ""
-	@echo "$(YELLOW)Container Status:$(NC)"
+	@echo -e "$(YELLOW)Container Status:$(NC)"
 	@docker-compose -f $(COMPOSE_FILE) ps
 	@echo ""
-	@echo "$(YELLOW)Image Information:$(NC)"
+	@echo -e "$(YELLOW)Image Information:$(NC)"
 	@docker images | grep openspp || echo "No OpenSPP images found"
 
 # Development helpers
 dev: ## Start in development mode (workers=0, dev mode enabled)
-	@echo "$(YELLOW)Starting in development mode (queue_job disabled)...$(NC)"
+	@echo -e "$(YELLOW)Starting in development mode (queue_job disabled)...$(NC)"
 	ODOO_DEV_MODE=true WORKERS=0 docker-compose -f $(COMPOSE_FILE) up -d
-	@echo "$(GREEN)Development mode started at http://localhost:8069$(NC)"
-	@echo "$(YELLOW)Warning: Queue jobs are disabled in dev mode$(NC)"
+	@echo -e "$(GREEN)Development mode started at http://localhost:8069$(NC)"
+	@echo -e "$(YELLOW)Warning: Queue jobs are disabled in dev mode$(NC)"
 
 prod-check: ## Validate production readiness
-	@echo "$(GREEN)Checking production readiness...$(NC)"
+	@echo -e "$(GREEN)Checking production readiness...$(NC)"
 	@echo -n "1. Checking workers configuration... "
 	@docker-compose -f $(COMPOSE_FILE) exec openspp grep "workers" /etc/openspp/odoo.conf | grep -q "workers = [2-9]" && echo "$(GREEN)✓$(NC)" || echo "$(RED)✗ Workers < 2$(NC)"
 	@echo -n "2. Checking queue_job in server_wide_modules... "
@@ -202,9 +202,9 @@ prod-check: ## Validate production readiness
 	@echo -n "4. Checking admin password... "
 	@docker-compose -f $(COMPOSE_FILE) exec openspp grep "admin_passwd" /etc/openspp/odoo.conf | grep -q "admin_passwd = admin" && echo "$(RED)✗ Using default password$(NC)" || echo "$(GREEN)✓$(NC)"
 	@echo ""
-	@echo "$(GREEN)Production check complete$(NC)"
+	@echo -e "$(GREEN)Production check complete$(NC)"
 
 login: ## Login to Nexus Docker registry
-	@echo "$(GREEN)Logging in to Nexus registry: $(PUSH_REGISTRY)$(NC)"
+	@echo -e "$(GREEN)Logging in to Nexus registry: $(PUSH_REGISTRY)$(NC)"
 	@docker login $(PUSH_REGISTRY)
-	@echo "$(GREEN)Successfully logged in to $(PUSH_REGISTRY)$(NC)"
+	@echo -e "$(GREEN)Successfully logged in to $(PUSH_REGISTRY)$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ push: ## Push images to Nexus registry
 
 scan: ## Security scan with Trivy
 	@echo -e "$(GREEN)Scanning images for vulnerabilities...$(NC)"
-	@which trivy > /dev/null || (echo "$(RED)Trivy not installed. Install from: https://github.com/aquasecurity/trivy$(NC)" && exit 1)
+	@which trivy > /dev/null || (echo -e "$(RED)Trivy not installed. Install from: https://github.com/aquasecurity/trivy$(NC)" && exit 1)
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest
 	trivy image --severity HIGH,CRITICAL $(IMAGE_NAME):latest-slim
 

--- a/NEXUS_DOCKER_SETUP.md
+++ b/NEXUS_DOCKER_SETUP.md
@@ -123,9 +123,11 @@ docker build -t openspp:latest .
 
 1. **Check secret names**: Ensure using the correct secret names (nexus_username vs nexus_user)
 2. **Verify credentials**: Test login manually:
+
    ```bash
    echo "your-password" | docker login 172.20.0.26:8082 -u "your-username" --password-stdin
    ```
+
 3. **Check network access**: Ensure the CI runner can reach 172.20.0.26:8082
 
 ### Push Failures

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Production-ready Docker images for OpenSPP Social Protection Platform based on O
 ## Docker Registry
 
 Images are hosted on ACN Nexus Docker Registry:
+
 - **Public access (pull):** `docker.acn.fr/openspp/openspp`
 - **Push access:** `docker-push.acn.fr/openspp/openspp` (requires authentication)
 
@@ -27,28 +28,32 @@ Images are hosted on ACN Nexus Docker Registry:
 ### Using Docker Compose (Development)
 
 1. Clone this repository:
-```bash
-git clone https://github.com/openspp/openspp-packaging-docker.git
-cd openspp-packaging-docker
-```
+
+   ```bash
+   git clone https://github.com/openspp/openspp-packaging-docker.git
+   cd openspp-packaging-docker
+   ```
 
 2. Build and start the services:
-```bash
-# Build the image (pulls from APT repository)
-docker compose build
 
-# Start the services
-docker compose up -d
-```
+   ```bash
+   # Build the image (pulls from APT repository)
+   docker compose build
+
+   # Start the services
+   docker compose up -d
+   ```
 
 3. Initialize the database (first run only):
-```bash
-docker compose exec openspp env INIT_DATABASE=true openspp-server
-```
 
-4. Access OpenSPP at http://localhost:8069
+   ```bash
+   docker compose exec openspp env INIT_DATABASE=true openspp-server
+   ```
+
+4. Access OpenSPP at [http://localhost:8069](http://localhost:8069)
 
 Default credentials:
+
 - Username: admin
 - Password: admin
 
@@ -80,12 +85,14 @@ docker run -d \
 ## Image Variants
 
 ### Standard Image (Ubuntu 24.04 LTS)
+
 - **Base**: Ubuntu 24.04 LTS
 - **Size**: ~1.5GB
 - **Use case**: Production deployments requiring maximum compatibility
 - **Tag**: `docker.acn.fr/openspp/openspp:latest`
 
 ### Slim Image (Debian Bookworm)
+
 - **Base**: Debian bookworm-slim
 - **Size**: ~1.0GB
 - **Use case**: Resource-constrained environments
@@ -96,6 +103,7 @@ docker run -d \
 ### Environment Variables
 
 #### Database Configuration
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DB_HOST` | `db` | PostgreSQL host |
@@ -105,6 +113,7 @@ docker run -d \
 | `DB_NAME` | `openspp` | Database name |
 
 #### Odoo Configuration
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ODOO_ADMIN_PASSWORD` | random | Master admin password |
@@ -114,6 +123,7 @@ docker run -d \
 | `ODOO_PROXY_MODE` | `False` | Enable proxy mode |
 
 #### Initialization
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `INIT_DATABASE` | `false` | Initialize database on startup |
@@ -141,7 +151,8 @@ docker run -d \
 
 OpenSPP requires the `queue_job` module for asynchronous operations. **This is CRITICAL for proper functioning.**
 
-### Requirements:
+### Requirements
+
 1. **Workers MUST be > 0** (minimum 2 for production)
    - Set `ODOO_WORKERS=2` or higher
    - Development mode (`ODOO_DEV_MODE=true`) sets workers to 0, disabling queue_job
@@ -150,8 +161,10 @@ OpenSPP requires the `queue_job` module for asynchronous operations. **This is C
    - On first run with `INIT_DATABASE=true`, queue_job is installed automatically
    - **Restart required** after installing queue_job for the job runner to start
 
-### Verification:
+### Verification
+
 Check if queue jobs are running:
+
 ```bash
 # Check workers configuration
 docker exec openspp grep workers /etc/openspp/odoo.conf
@@ -165,18 +178,20 @@ docker exec openspp grep workers /etc/openspp/odoo.conf
 ### Using Docker Compose
 
 1. Create Docker secrets:
-```bash
-echo "openspp" | docker secret create db_name -
-echo "openspp" | docker secret create db_user -
-echo "strong_password" | docker secret create db_password -
-echo "admin_password" | docker secret create admin_password -
-echo "redis_password" | docker secret create redis_password -
-```
+
+   ```bash
+   echo "openspp" | docker secret create db_name -
+   echo "openspp" | docker secret create db_user -
+   echo "strong_password" | docker secret create db_password -
+   echo "admin_password" | docker secret create admin_password -
+   echo "redis_password" | docker secret create redis_password -
+   ```
 
 2. Deploy with production configuration:
-```bash
-docker compose -f docker-compose.prod.yml up -d
-```
+
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d
+   ```
 
 ### Kubernetes Deployment
 
@@ -209,7 +224,7 @@ make build-all
 docker buildx build --platform linux/amd64,linux/arm64 -t openspp:local .
 ```
 
-Note: The images automatically install the latest daily build from the OpenSPP APT repository at https://builds.acn.fr/repository/apt-openspp-daily/
+Note: The images automatically install the latest daily build from the OpenSPP APT repository at [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 
 ### Pushing to Nexus Registry
 
@@ -224,12 +239,14 @@ make push
 ```
 
 Images will be available at:
+
 - `docker.acn.fr/openspp/openspp:latest` (public access)
 - `docker.acn.fr/openspp/openspp:latest-slim` (public access)
 
 ### CI/CD Pipeline
 
 The Woodpecker CI pipeline automatically:
+
 1. Creates multi-arch Docker images (pulling from APT repository)
 2. Runs security scans with Trivy
 3. Tests the images
@@ -240,6 +257,7 @@ The Woodpecker CI pipeline automatically:
 ### Health Check
 
 The container includes a health check endpoint:
+
 ```bash
 curl http://localhost:8069/web/health
 ```
@@ -247,6 +265,7 @@ curl http://localhost:8069/web/health
 ### Logs
 
 View container logs:
+
 ```bash
 docker logs -f openspp
 ```
@@ -254,6 +273,7 @@ docker logs -f openspp
 ### Metrics
 
 For production monitoring, consider:
+
 - Prometheus + Grafana for metrics
 - ELK/EFK stack for log aggregation
 - APM tools like New Relic or DataDog
@@ -261,6 +281,7 @@ For production monitoring, consider:
 ## Troubleshooting
 
 ### Database Connection Issues
+
 ```bash
 # Check database connectivity
 docker exec openspp pg_isready -h db -U openspp
@@ -270,12 +291,14 @@ docker logs openspp | grep -i database
 ```
 
 ### Permission Issues
+
 ```bash
 # Fix volume permissions
 docker exec -u root openspp chown -R openspp:openspp /var/lib/openspp
 ```
 
 ### Module Installation
+
 ```bash
 # Install modules manually
 docker exec openspp env UPDATE_MODULES=base,web openspp-server
@@ -287,6 +310,7 @@ docker exec openspp env UPDATE_MODULES=base,web openspp-server
 
 1. Place addons in `custom-addons/` directory
 2. Restart container to detect new modules:
+
 ```bash
 docker compose restart openspp
 ```
@@ -294,6 +318,7 @@ docker compose restart openspp
 ### Debugging
 
 Enable development mode:
+
 ```bash
 docker compose exec openspp env ODOO_DEV_MODE=true openspp-server
 ```
@@ -304,10 +329,10 @@ LGPL-3.0 - See [LICENSE](LICENSE) file for details.
 
 ## Support
 
-- Documentation: https://docs.openspp.org
-- Issues: https://github.com/openspp/openspp-packaging-docker/issues
-- Community: https://community.openspp.org
-- APT Repository (Daily): https://builds.acn.fr/repository/apt-openspp-daily/
+- Documentation: [https://docs.openspp.org](https://docs.openspp.org)
+- Issues: [https://github.com/openspp/openspp-packaging-docker/issues](https://github.com/openspp/openspp-packaging-docker/issues)
+- Community: [https://community.openspp.org](https://community.openspp.org)
+- APT Repository (Daily): [https://builds.acn.fr/repository/apt-openspp-daily/](https://builds.acn.fr/repository/apt-openspp-daily/)
 
 ## Contributing
 

--- a/TEST.md
+++ b/TEST.md
@@ -28,40 +28,44 @@ chmod +x test-images.sh
 ### Manual Testing with Docker Compose
 
 1. **Test the latest images from registry:**
-```bash
-# Start services
-docker-compose -f docker-compose.test.yml up -d
 
-# Watch logs
-docker-compose -f docker-compose.test.yml logs -f
+   ```bash
+   # Start services
+   docker-compose -f docker-compose.test.yml up -d
 
-# Access OpenSPP
-open http://localhost:8069
+   # Watch logs
+   docker-compose -f docker-compose.test.yml logs -f
 
-# Stop services
-docker-compose -f docker-compose.test.yml down -v
-```
+   # Access OpenSPP
+   open http://localhost:8069
+
+   # Stop services
+   docker-compose -f docker-compose.test.yml down -v
+   ```
 
 2. **Test specific image tags:**
-```bash
-# Test weekly build
-IMAGE_TAG=weekly docker-compose -f docker-compose.test.yml up -d
 
-# Test specific version
-IMAGE_TAG=v1.0.0 docker-compose -f docker-compose.test.yml up -d
+   ```bash
+   # Test weekly build
+   IMAGE_TAG=weekly docker-compose -f docker-compose.test.yml up -d
 
-# Test slim variant
-IMAGE_TAG=latest-slim docker-compose -f docker-compose.test.yml up -d
-```
+   # Test specific version
+   IMAGE_TAG=v1.0.0 docker-compose -f docker-compose.test.yml up -d
+
+   # Test slim variant
+   IMAGE_TAG=latest-slim docker-compose -f docker-compose.test.yml up -d
+   ```
 
 3. **Test with database initialization:**
-```bash
-INIT_DATABASE=true docker-compose -f docker-compose.test.yml up -d
-```
+
+   ```bash
+   INIT_DATABASE=true docker-compose -f docker-compose.test.yml up -d
+   ```
 
 ## Test Scenarios
 
 ### 1. Basic Functionality Test
+
 - ✅ Image pulls successfully
 - ✅ Container starts without errors
 - ✅ Health endpoint responds
@@ -69,6 +73,7 @@ INIT_DATABASE=true docker-compose -f docker-compose.test.yml up -d
 - ✅ Can connect to PostgreSQL
 
 ### 2. Database Operations Test
+
 ```bash
 # Initialize database with modules
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -80,6 +85,7 @@ docker-compose -f docker-compose.test.yml exec openspp \
 ```
 
 ### 3. Performance Test
+
 ```bash
 # Check response time
 time curl -s http://localhost:8069 > /dev/null
@@ -92,6 +98,7 @@ ab -n 100 -c 10 http://localhost:8069/
 ```
 
 ### 4. Module Installation Test
+
 ```bash
 # Install OpenSPP modules
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -101,6 +108,7 @@ docker-compose -f docker-compose.test.yml exec openspp \
 ```
 
 ### 5. Multi-Architecture Test
+
 ```bash
 # Test on different architectures (if available)
 docker run --rm --platform linux/amd64 \
@@ -111,12 +119,14 @@ docker run --rm --platform linux/amd64 \
 ## Validation Checklist
 
 ### Image Build Validation
+
 - [ ] Image size is reasonable (~1.5GB for Ubuntu, ~1.0GB for slim)
 - [ ] No security vulnerabilities in base image
 - [ ] All required files are present
 - [ ] Proper user permissions (non-root)
 
 ### Runtime Validation
+
 - [ ] Container starts successfully
 - [ ] No critical errors in logs
 - [ ] Health check passes
@@ -126,6 +136,7 @@ docker run --rm --platform linux/amd64 \
 - [ ] Custom addons can be loaded
 
 ### Security Validation
+
 - [ ] Running as non-root user (openspp)
 - [ ] No exposed secrets in environment
 - [ ] Proper file permissions
@@ -134,6 +145,7 @@ docker run --rm --platform linux/amd64 \
 ## Debugging Failed Tests
 
 ### Container Won't Start
+
 ```bash
 # Check logs
 docker-compose -f docker-compose.test.yml logs openspp
@@ -146,6 +158,7 @@ docker-compose -f docker-compose.test.yml run openspp /bin/bash
 ```
 
 ### Database Connection Issues
+
 ```bash
 # Test database connectivity
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -156,6 +169,7 @@ docker-compose -f docker-compose.test.yml logs db
 ```
 
 ### Module Import Errors
+
 ```bash
 # Check Python environment
 docker-compose -f docker-compose.test.yml exec openspp \
@@ -181,11 +195,13 @@ REGISTRY=localhost:5000 docker-compose -f docker-compose.test.yml up -d
 ## Automated CI Testing
 
 The GitHub Actions workflow automatically tests images on:
+
 - Pull requests
 - Weekly scheduled builds
 - Manual workflow dispatches
 
 To manually trigger tests:
+
 1. Go to [Actions](https://github.com/OpenSPP/openspp-packaging-docker/actions)
 2. Select "Docker Build and Push"
 3. Click "Run workflow"
@@ -212,6 +228,7 @@ docker rmi $(docker images | grep openspp | awk '{print $3}')
 ## Reporting Issues
 
 If tests fail:
+
 1. Capture the error logs
 2. Note the image tag and registry
 3. Document the test scenario

--- a/WOODPECKER_AGENT_SETUP.md
+++ b/WOODPECKER_AGENT_SETUP.md
@@ -19,7 +19,7 @@ docker --version
 
 Since the Nexus Docker registry at `172.20.0.26:8082` uses HTTP (not HTTPS), the Docker daemon on the Woodpecker agent host must be configured to allow this insecure registry.
 
-#### Edit Docker daemon configuration:
+#### Edit Docker daemon configuration
 
 ```bash
 sudo nano /etc/docker/daemon.json
@@ -33,13 +33,13 @@ Add or update the configuration:
 }
 ```
 
-#### Restart Docker:
+#### Restart Docker
 
 ```bash
 sudo systemctl restart docker
 ```
 
-#### Verify the configuration:
+#### Verify the configuration
 
 ```bash
 docker info | grep -A 5 "Insecure Registries"
@@ -52,6 +52,7 @@ You should see `172.20.0.26:8082` listed.
 The Woodpecker agent must have access to the Docker socket. This is typically at `/var/run/docker.sock`.
 
 Verify the socket exists:
+
 ```bash
 ls -la /var/run/docker.sock
 ```
@@ -59,10 +60,12 @@ ls -la /var/run/docker.sock
 ### 4. Network Access
 
 The agent must be able to reach:
+
 - `172.20.0.26:8082` - Nexus Docker registry (internal network)
 - GitHub for cloning repositories
 
 Test connectivity:
+
 ```bash
 # Test Nexus registry
 curl -I http://172.20.0.26:8082/v2/
@@ -104,6 +107,7 @@ docker run -d \
 ### "Cannot connect to Docker daemon"
 
 Ensure:
+
 1. Docker is running on the host
 2. The socket is mounted correctly
 3. The agent has permissions to access the socket
@@ -115,6 +119,7 @@ This means the insecure-registries configuration is missing. Add `172.20.0.26:80
 ### "unauthorized: authentication required"
 
 Check:
+
 1. Nexus credentials are correct
 2. The user has push permissions to the repository
 3. The repository exists in Nexus
@@ -129,6 +134,7 @@ Check:
 ## Alternative: Docker-in-Docker
 
 If socket mounting is not desired, you can use Docker-in-Docker (DinD), but this requires:
+
 - Privileged mode (security risk)
 - More complex configuration
 - Potential performance overhead

--- a/WOODPECKER_AUTH_TROUBLESHOOTING.md
+++ b/WOODPECKER_AUTH_TROUBLESHOOTING.md
@@ -1,8 +1,10 @@
 # Woodpecker CI Authentication Troubleshooting
 
 ## Issue
+
 The Woodpecker CI pipeline is failing with authentication errors when trying to push to the Nexus Docker registry:
-```
+
+``` text
 Logging in with username '********' to registry 'docker-push.acn.fr'
 ERR execution failed error="error authenticating: exit status 1"
 ```
@@ -10,23 +12,29 @@ ERR execution failed error="error authenticating: exit status 1"
 ## Possible Causes
 
 ### 1. Secret Names Mismatch
+
 The GitHub Actions workflow uses uppercase secret names:
+
 - `NEXUS_USERNAME`
 - `NEXUS_PASSWORD`
 
 While Woodpecker configuration uses lowercase:
+
 - `nexus_username`
 - `nexus_password`
 
 **Solution**: Ensure secrets are configured in Woodpecker with the exact same names used in the pipeline.
 
 ### 2. Secret Configuration in Woodpecker
+
 Secrets need to be properly configured in Woodpecker either:
+
 - **Repository secrets**: Add via Woodpecker UI under repository settings
 - **Organization secrets**: Add at organization level if using shared credentials
 - **Global secrets**: Configure in Woodpecker server for all repositories
 
 **To add secrets in Woodpecker UI:**
+
 1. Go to your repository in Woodpecker
 2. Click on Settings → Secrets
 3. Add new secrets:
@@ -36,35 +44,44 @@ Secrets need to be properly configured in Woodpecker either:
    - Value: Your Nexus password
 
 ### 3. Plugin Authentication Format
+
 The `woodpeckerci/plugin-docker-buildx` plugin might have issues with certain authentication methods.
 
 **Alternative approaches provided:**
 
 #### Option A: Debug Configuration (`.woodpecker-debug.yml`)
+
 Use this to test secret availability and manual Docker login:
+
 ```bash
 # Rename to .woodpecker.yml to test
 mv .woodpecker-debug.yml .woodpecker.yml
 ```
 
 #### Option B: Alternative Configuration (`.woodpecker-alt.yml`)
+
 Uses Docker commands directly instead of the plugin:
+
 ```bash
 # Rename to .woodpecker.yml to use
 mv .woodpecker-alt.yml .woodpecker.yml
 ```
 
 ### 4. Registry URL Format
+
 Ensure the registry URL is correct:
+
 - Push URL: `docker-push.acn.fr`
 - Pull URL: `docker.acn.fr`
 
 ### 5. Permissions
+
 The repository must be marked as "Trusted" in Woodpecker to use privileged mode required for Docker builds.
 
 ## Testing Steps
 
 1. **Test secret availability:**
+
    ```bash
    # Use the debug configuration
    cp .woodpecker-debug.yml .woodpecker.yml
@@ -84,7 +101,9 @@ The repository must be marked as "Trusted" in Woodpecker to use privileged mode 
    If the plugin continues to fail, use the alternative configuration that bypasses the plugin.
 
 ## Working GitHub Actions Reference
+
 The GitHub Actions workflow (`.github/workflows/docker-build.yml`) successfully authenticates using:
+
 ```yaml
 - name: Log in to Nexus Registry
   uses: docker/login-action@v3

--- a/WOODPECKER_FIX.md
+++ b/WOODPECKER_FIX.md
@@ -30,6 +30,7 @@ The new configuration (`.woodpecker-working.yml`) uses the same pattern as the w
 ## Key Changes
 
 ### Before (Not Working)
+
 ```yaml
 build:
   image: woodpeckerci/plugin-docker-buildx
@@ -43,6 +44,7 @@ build:
 ```
 
 ### After (Working)
+
 ```yaml
 build:
   image: docker:latest
@@ -56,6 +58,7 @@ build:
 ## Required Secrets
 
 Ensure these secrets are configured in Woodpecker:
+
 - `nexus_username` or `nexus_user`
 - `nexus_password`
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Production Docker Compose Configuration for OpenSPP
 # This configuration includes:
 # - Security hardening

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,6 @@
 # ABOUTME: Docker Compose configuration for testing OpenSPP images
 # ABOUTME: Quick validation that built images work correctly with database
 
-version: '3.8'
-
 services:
   # PostgreSQL Database
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL Database
   db:


### PR DESCRIPTION
- Fix colored output for Makefile
- Fix markdownlint errors
- Remove version in docker compose, it is obsolete and should not be used anymore, see [here](https://docs.docker.com/reference/compose-file/version-and-name/) for more info
- Add newline EOF for docker-compose files