### PR TITLE
Rework the Dockerfile and the Docker bake file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,76 +2,87 @@
 # ABOUTME: Multi-stage build with security hardening and multi-arch support
 
 # Build arguments for version control
-ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETARCH=amd64
+ARG BASE_IMAGE=ubuntu:24.04
 
 # ============================================
-# Stage 1: Configure APT repository
+# Stage 1: Install OpenSPP package
 # ============================================
-FROM ubuntu:24.04 AS downloader
+FROM ${BASE_IMAGE} AS openspp_installer
 
-ARG TARGETARCH
-ARG DEBIAN_FRONTEND
-
-# Install minimal tools for repository setup
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-
-# Configure OpenSPP daily APT repository
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
-    gpg --dearmor -o /etc/apt/keyrings/openspp.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
-    /etc/apt/sources.list.d/openspp.list && \
-    apt-get update && \
-    apt-cache show openspp-17-daily
-
-# ============================================
-# Stage 2: Install OpenSPP package
-# ============================================
-FROM ubuntu:24.04 AS installer
-
-ARG DEBIAN_FRONTEND
-ARG TARGETARCH
-
-# Copy repository configuration from downloader stage
-COPY --from=downloader /etc/apt/keyrings/openspp.gpg /etc/apt/keyrings/
-COPY --from=downloader /etc/apt/sources.list.d/openspp.list /etc/apt/sources.list.d/
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Install ca-certificates first, then OpenSPP package from APT repository
 # Create a fake systemctl to handle postinst scripts in Docker
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
+# Configure OpenSPP daily APT repository
+RUN mkdir -p /etc/apt/keyrings \
     && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+    && curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
+      gpg --dearmor -o /etc/apt/keyrings/openspp.gpg \
+    && gpg --show-keys /etc/apt/keyrings/openspp.gpg | grep "BE1468830EFDA9887F0BBD077A335D5FB4C1A749" \
+    && echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
+      /etc/apt/sources.list.d/openspp.list \
     && echo '#!/bin/sh' > /usr/bin/systemctl \
     && echo 'exit 0' >> /usr/bin/systemctl \
     && chmod +x /usr/bin/systemctl \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
-        openspp-17-daily \
+       openspp-17-daily \
     && rm -f /usr/bin/systemctl \
     && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# ============================================
+# Stage 2: Install wkhtmltopdf
+# ============================================
+FROM ${BASE_IMAGE} AS wkhtmltopdf_installer
+
+ARG BASE_IMAGE=ubuntu:24.04
+ARG TARGETARCH=amd64
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Install ca-certificates first, then OpenSPP package from APT repository
+# Create a fake systemctl to handle postinst scripts in Docker
+# Configure OpenSPP daily APT repository
+WORKDIR /tmp
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && case "${BASE_IMAGE}" in \
+    *"debian"* | *"bookworm"*) WKHTMLTOPDF_DISTRIB=bookworm && WKHTMLTOPDF_SHA=e9f95436298c77cc9406bd4bbd242f4771d0a4b2  ;; \
+    *"ubuntu"*)  WKHTMLTOPDF_DISTRIB=jammy && WKHTMLTOPDF_SHA=967390a759707337b46d1c02452e2bb6b2dc6d59  ;; \
+    esac \
+    && curl -o wkhtmltox.deb -sSL "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.${WKHTMLTOPDF_DISTRIB}_${TARGETARCH}.deb" \
+    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha1sum -c - \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
 # Stage 3: Final production image
 # ============================================
-FROM ubuntu:24.04
+FROM ${BASE_IMAGE}
 
-ARG DEBIAN_FRONTEND
-ARG BUILD_DATE
-ARG VCS_REF
+ARG BASE_IMAGE=ubuntu:24.04
+ARG BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GID=1001
+ARG OPENSPP_LEFT_TO_RIGHT_LANGUAGE_SUPPORT=false
+ARG OPENSPP_VERSION=17.0-daily
+ARG PYTHONUNBUFFERED=1
+ARG PYTHONDONTWRITEBYTECODE=1
+ARG UID=1001
+ARG VCS_REF="unspecified"
+
+SHELL ["/bin/bash", "-euox", "pipefail", "-c"]
 
 # OCI Image Specification labels
 LABEL org.opencontainers.image.title="OpenSPP" \
       org.opencontainers.image.description="OpenSPP Social Protection Platform based on Odoo 17" \
-      org.opencontainers.image.version="17.0-daily" \
+      org.opencontainers.image.version="${OPENSPP_VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.authors="OpenSPP Team <support@openspp.org>" \
@@ -80,69 +91,58 @@ LABEL org.opencontainers.image.title="OpenSPP" \
       org.opencontainers.image.source="https://github.com/openspp/openspp-packaging-docker" \
       org.opencontainers.image.vendor="OpenSPP" \
       org.opencontainers.image.licenses="LGPL-3.0" \
-      org.opencontainers.image.base.name="ubuntu:24.04"
+      org.opencontainers.image.base.name="${BASE_IMAGE}"
+
+# Set environment variables
+# Generate locale C.UTF-8 for postgres and general locale data
+# We need to set the DEBIAN_FRONTEND variable to prevent tzdata from asking us questions
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    UID=${UID} \
+    GID=${GID} \
+    PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    ODOO_RC=/etc/openspp/odoo.conf \
+    PATH="/opt/openspp/venv/bin:$PATH" \
+    HOME="/var/lib/openspp"
+
+COPY --from=wkhtmltopdf_installer /tmp/wkhtmltox.deb /tmp/wkhtmltox.deb
 
 # Install only runtime dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+# Create openspp user and group with consistent IDs
+# Create necessary directories with proper permissions
+RUN apt-get update \
+    && DEBIAN_FRONTEND=${DEBIAN_FRONTEND} apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        fontconfig \
-        fonts-liberation \
-        fonts-noto \
-        fonts-noto-cjk \
-        fonts-noto-color-emoji \
-        gnupg \
-        gosu \
-        libjs-jquery \
-        libpq5 \
-        libssl3 \
         locales \
-        node-less \
-        npm \
         postgresql-client \
         python3 \
         python3-venv \
-        python3-magic \
-        python3-num2words \
-        python3-odf \
-        python3-pdfminer \
-        python3-phonenumbers \
-        python3-pyldap \
-        python3-qrcode \
-        python3-renderpm \
-        python3-slugify \
-        python3-vobject \
-        python3-watchdog \
-        python3-xlrd \
-        python3-xlwt \
         tzdata \
+        /tmp/wkhtmltox.deb \
+    && if [ "${OPENSPP_LEFT_TO_RIGHT_LANGUAGE_SUPPORT}" = "true" ]; then \
+        apt-get install -y --no-install-recommends \
+            node-less \
+            npm \
+        && npm install -g rtlcss \
+        && apt-get remove -y npm ; \
+    fi \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
-    && npm install -g rtlcss \
+    && apt-get upgrade -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Set locale environment
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
-
-# Create openspp user and group with consistent IDs
-# Check if GID 1000 exists, if so use a different one (9999)
-RUN (groupadd -r -g 1000 openspp 2>/dev/null || groupadd -r openspp) && \
-    useradd -r -g openspp \
+    && apt-get autopurge -yqq \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /tmp/wkhtmltox.deb \
+    && bash -c "if ! getent group ${GID}; then groupadd -r -g ${GID} openspp; fi" \
+    && useradd -l -u ${UID} -r -g ${GID} \
         -d /var/lib/openspp \
         -s /bin/bash \
-        -m openspp
-
-# Copy OpenSPP installation from installer stage with correct ownership
-COPY --chown=openspp:openspp --from=installer /opt/openspp /opt/openspp
-COPY --from=installer /usr/bin/openspp-* /usr/bin/
-COPY --chown=openspp:openspp --from=installer /etc/openspp /etc/openspp
-
-# Create necessary directories with proper permissions
-RUN mkdir -p \
+        -m openspp \
+    && mkdir -p \
         /var/lib/openspp \
         /var/log/openspp \
         /mnt/extra-addons \
@@ -153,17 +153,15 @@ RUN mkdir -p \
         /mnt/extra-addons \
         /opt/openspp/data
 
+# Copy OpenSPP installation from installer stage with correct ownership
+COPY --chown=openspp:openspp --from=openspp_installer /opt/openspp /opt/openspp
+COPY --from=openspp_installer /usr/bin/openspp-* /usr/bin/
+COPY --chown=openspp:openspp --from=openspp_installer /etc/openspp /etc/openspp
+
 # Copy configuration and entrypoint scripts
 COPY --chown=openspp:openspp config/odoo.conf /etc/openspp/odoo.conf
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
 COPY --chmod=755 wait-for-psql.py /usr/local/bin/
-
-# Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    ODOO_RC=/etc/openspp/odoo.conf \
-    PATH="/opt/openspp/venv/bin:$PATH" \
-    HOME="/var/lib/openspp"
 
 # Create volume mount points
 VOLUME ["/var/lib/openspp", "/mnt/extra-addons"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,11 @@ RUN apt-get update \
         ca-certificates \
         curl \
     && case "${BASE_IMAGE}" in \
-    *"debian"* | *"bookworm"*) WKHTMLTOPDF_DISTRIB=bookworm && WKHTMLTOPDF_SHA=e9f95436298c77cc9406bd4bbd242f4771d0a4b2  ;; \
-    *"ubuntu"*)  WKHTMLTOPDF_DISTRIB=jammy && WKHTMLTOPDF_SHA=967390a759707337b46d1c02452e2bb6b2dc6d59  ;; \
+    *"debian"* | *"bookworm"*) WKHTMLTOPDF_DISTRIB=bookworm && WKHTMLTOPDF_SHA=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d  ;; \
+    *"ubuntu"*)  WKHTMLTOPDF_DISTRIB=jammy && WKHTMLTOPDF_SHA=4f723b2691ad8638a9df960e0421d346d7315083e3583a334f33362280ddba15  ;; \
     esac \
     && curl -o wkhtmltox.deb -sSL "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.${WKHTMLTOPDF_DISTRIB}_${TARGETARCH}.deb" \
-    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha1sum -c - \
+    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha256sum -c - \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
@@ -77,7 +77,7 @@ ARG PYTHONDONTWRITEBYTECODE=1
 ARG UID=1001
 ARG VCS_REF="unspecified"
 
-SHELL ["/bin/bash", "-euox", "pipefail", "-c"]
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # OCI Image Specification labels
 LABEL org.opencontainers.image.title="OpenSPP" \
@@ -132,7 +132,6 @@ RUN apt-get update \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 \
-    && apt-get upgrade -y \
     && apt-get clean \
     && apt-get autopurge -yqq \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -54,13 +54,13 @@ RUN apt-get update \
         ca-certificates \
         curl \
     && WKHTMLTOPDF_DISTRIB=bookworm \
-    && WKHTMLTOPDF_SHA=e9f95436298c77cc9406bd4bbd242f4771d0a4b2 \
+    && WKHTMLTOPDF_SHA=98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d \
     && curl -o wkhtmltox.deb -sSL "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.${WKHTMLTOPDF_DISTRIB}_${TARGETARCH}.deb" \
-    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha1sum -c - \
+    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha256sum -c - \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
-# Stage 2: Final slim production image
+# Stage 3: Final slim production image
 # ============================================
 # FROM debian:bookworm-slim
 FROM debian:bookworm-slim
@@ -94,11 +94,11 @@ LABEL org.opencontainers.image.title="OpenSPP Slim" \
 # Set environment variables
 # Generate locale C.UTF-8 for postgres and general locale data
 # We need to set the DEBIAN_FRONTEND variable to prevent tzdata from asking us questions
-# ENV LANG=en_US.UTF-8 \
-#     LANGUAGE=en_US:en \
-#     LC_ALL=en_US.UTF-8 \
 ENV UID=${UID} \
     GID=${GID} \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
     PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
     PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
     ODOO_RC=/etc/openspp/odoo.conf \

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -2,53 +2,29 @@
 # ABOUTME: Optimized for size while maintaining compatibility
 
 # Build arguments for version control
-ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETARCH=amd64
+ARG BASE_IMAGE=debian:bookworm-slim
 
 # ============================================
-# Stage 1: Configure APT repository
+# Stage 1: Install OpenSPP package
 # ============================================
-FROM debian:bookworm-slim as downloader
+# FROM debian:bookworm-slim AS installer
+FROM debian:bookworm-slim AS installer
 
-ARG TARGETARCH
-ARG DEBIAN_FRONTEND
-
-# Install minimal tools for repository setup
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        gnupg \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-
-# Configure OpenSPP daily APT repository
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
-    gpg --dearmor -o /etc/apt/keyrings/openspp.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
-    /etc/apt/sources.list.d/openspp.list && \
-    apt-get update && \
-    apt-cache show openspp-17-daily
-
-# ============================================
-# Stage 2: Install OpenSPP package
-# ============================================
-FROM debian:bookworm-slim as installer
-
-ARG DEBIAN_FRONTEND
-ARG TARGETARCH
-
-# Copy repository configuration from downloader stage
-COPY --from=downloader /etc/apt/keyrings/openspp.gpg /etc/apt/keyrings/
-COPY --from=downloader /etc/apt/sources.list.d/openspp.list /etc/apt/sources.list.d/
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Install ca-certificates first, then OpenSPP package from APT repository
 # Create a fake systemctl to handle postinst scripts in Docker
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
+        gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://builds.acn.fr/repository/apt-keys/openspp/public.key | \
+    gpg --dearmor -o /etc/apt/keyrings/openspp.gpg \
+    && gpg --show-keys /etc/apt/keyrings/openspp.gpg | grep "BE1468830EFDA9887F0BBD077A335D5FB4C1A749" \
+    && echo "deb [signed-by=/etc/apt/keyrings/openspp.gpg] https://builds.acn.fr/repository/apt-openspp-daily bookworm main" > \
+    /etc/apt/sources.list.d/openspp.list \
     && apt-get update \
     && echo '#!/bin/sh' > /usr/bin/systemctl \
     && echo 'exit 0' >> /usr/bin/systemctl \
@@ -60,18 +36,51 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================
-# Stage 3: Final slim production image
+# Stage 2: Install wkhtmltopdf
 # ============================================
+FROM ${BASE_IMAGE} AS wkhtmltopdf_installer
+
+ARG BASE_IMAGE=debian:bookworm-slim
+ARG TARGETARCH=amd64
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# Install ca-certificates first, then OpenSPP package from APT repository
+# Create a fake systemctl to handle postinst scripts in Docker
+# Configure OpenSPP daily APT repository
+WORKDIR /tmp
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+    && WKHTMLTOPDF_DISTRIB=bookworm \
+    && WKHTMLTOPDF_SHA=e9f95436298c77cc9406bd4bbd242f4771d0a4b2 \
+    && curl -o wkhtmltox.deb -sSL "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.${WKHTMLTOPDF_DISTRIB}_${TARGETARCH}.deb" \
+    && echo "${WKHTMLTOPDF_SHA}" wkhtmltox.deb | sha1sum -c - \
+    && rm -rf /var/lib/apt/lists/*
+
+# ============================================
+# Stage 2: Final slim production image
+# ============================================
+# FROM debian:bookworm-slim
 FROM debian:bookworm-slim
 
-ARG DEBIAN_FRONTEND
-ARG BUILD_DATE
-ARG VCS_REF
+ARG BASE_IMAGE=debian:bookworm-slim
+ARG BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GID=1001
+ARG OPENSPP_VERSION=17.0-daily
+ARG PYTHONUNBUFFERED=1
+ARG PYTHONDONTWRITEBYTECODE=1
+ARG UID=1001
+ARG VCS_REF="unspecified"
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # OCI Image Specification labels
 LABEL org.opencontainers.image.title="OpenSPP Slim" \
       org.opencontainers.image.description="Lightweight OpenSPP Social Protection Platform based on Debian slim" \
-      org.opencontainers.image.version="17.0-daily" \
+      org.opencontainers.image.version="${OPENSPP_VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.authors="OpenSPP Team <support@openspp.org>" \
@@ -80,53 +89,50 @@ LABEL org.opencontainers.image.title="OpenSPP Slim" \
       org.opencontainers.image.source="https://github.com/openspp/openspp-packaging-docker" \
       org.opencontainers.image.vendor="OpenSPP" \
       org.opencontainers.image.licenses="LGPL-3.0" \
-      org.opencontainers.image.base.name="debian:bookworm-slim"
+      org.opencontainers.image.base.name="${BASE_IMAGE}"
+
+# Set environment variables
+# Generate locale C.UTF-8 for postgres and general locale data
+# We need to set the DEBIAN_FRONTEND variable to prevent tzdata from asking us questions
+# ENV LANG=en_US.UTF-8 \
+#     LANGUAGE=en_US:en \
+#     LC_ALL=en_US.UTF-8 \
+ENV UID=${UID} \
+    GID=${GID} \
+    PYTHONUNBUFFERED=${PYTHONUNBUFFERED} \
+    PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE} \
+    ODOO_RC=/etc/openspp/odoo.conf \
+    PATH="/opt/openspp/venv/bin:$PATH" \
+    HOME="/var/lib/openspp"
+
+COPY --from=wkhtmltopdf_installer /tmp/wkhtmltox.deb /tmp/wkhtmltox.deb
 
 # Install only essential runtime dependencies
 # Keeping this minimal for the slim image
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=${DEBIAN_FRONTEND} apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        fontconfig \
-        fonts-liberation2 \
-        fonts-noto-core \
-        gosu \
-        libpq5 \
-        libssl3 \
         locales \
         postgresql-client \
         python3 \
         python3-venv \
         tzdata \
+        /tmp/wkhtmltox.deb \
     && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/share/doc/* \
     && rm -rf /usr/share/man/* \
-    && rm -rf /usr/share/info/*
-
-# Set locale environment
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
-
-# Create openspp user and group with consistent IDs
-# Check if GID 1000 exists, if so use a different one (9999)
-RUN (groupadd -r -g 1000 openspp 2>/dev/null || groupadd -r openspp) && \
-    useradd -r -g openspp \
+    && rm -rf /usr/share/info/* \
+    && rm -f /tmp/wkhtmltox.deb \
+    && bash -c "if ! getent group ${GID}; then groupadd -r -g ${GID} openspp; fi" \
+    && useradd -l -u ${UID} -r -g ${GID} \
         -d /var/lib/openspp \
         -s /bin/bash \
-        -m openspp
-
-# Copy OpenSPP installation from installer stage with correct ownership
-COPY --chown=openspp:openspp --from=installer /opt/openspp /opt/openspp
-COPY --from=installer /usr/bin/openspp-* /usr/bin/
-COPY --chown=openspp:openspp --from=installer /etc/openspp /etc/openspp
-
-# Create necessary directories with proper permissions
-RUN mkdir -p \
+        -m openspp \
+    && mkdir -p \
         /var/lib/openspp \
         /var/log/openspp \
         /mnt/extra-addons \
@@ -137,17 +143,15 @@ RUN mkdir -p \
         /mnt/extra-addons \
         /opt/openspp/data
 
+# Copy OpenSPP installation from installer stage with correct ownership
+COPY --chown=openspp:openspp --from=installer /opt/openspp /opt/openspp
+COPY --from=installer /usr/bin/openspp-* /usr/bin/
+COPY --chown=openspp:openspp --from=installer /etc/openspp /etc/openspp
+
 # Copy configuration and entrypoint scripts
 COPY --chown=openspp:openspp config/odoo.conf /etc/openspp/odoo.conf
 COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
 COPY --chmod=755 wait-for-psql.py /usr/local/bin/
-
-# Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    ODOO_RC=/etc/openspp/odoo.conf \
-    PATH="/opt/openspp/venv/bin:$PATH" \
-    HOME="/var/lib/openspp"
 
 # Create volume mount points
 VOLUME ["/var/lib/openspp", "/mnt/extra-addons"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,11 +1,31 @@
+
+variable "PUSH_REGISTRY" {
+  default = "docker-push.acn.fr"
+}
+variable "REGISTRY" {
+  default = "docker.acn.fr"
+}
+variable "REPO" {
+  default = "openspp/openspp"
+}
+variable "IMAGE_NAME" {
+  default = "${REGISTRY}/${REPO}"
+}
+variable "PUSH_IMAGE_NAME" {
+  default = "${PUSH_REGISTRY}/${REPO}"
+}
+variable "IMAGE_TAG" {
+  default = "daily"
+}
+
 group "default" {
   targets = [
-    "openspp-debian-bookworm-slim",
-    "openspp-debian-trixie-slim",
+    # "openspp-debian-bookworm-slim",
+    # "openspp-debian-trixie-slim",
     "openspp-ubuntu-24-04",
-    "openspp-python-3-14-slim-bookworm",
-    "openspp-python-3-13-slim-bookworm",
-    "openspp-python-3-12-slim-bookworm"
+    # "openspp-python-3-14-slim-bookworm",
+    # "openspp-python-3-13-slim-bookworm",
+    # "openspp-python-3-12-slim-bookworm"
   ]
 }
 
@@ -14,10 +34,13 @@ target "common" {
     BUILD_DATE              = "$(date -u +\"%Y-%m-%dT%H:%M:%SZ\")"
     DEBIAN_FRONTEND         = "noninteractive"
     GID                     = "1001"
+    OPENSPP_VERSION         = "17.0.1-daily+odoo17.0-1"
     PYTHONUNBUFFERED        = "1"
     PYTHONDONTWRITEBYTECODE = "1"
+    TARGETARCH              = "amd64"
     UID                     = "1001"
-    VCS_REF                 = "master"
+    VCS_REF                 = "master"    
+    OPENSPP_LEFT_TO_RIGHT_LANGUAGE_SUPPORT = "false"
   }
 }
 
@@ -25,10 +48,13 @@ target "openspp-debian-bookworm-slim" {
   inherits   = ["common"]
   context    = "."
   dockerfile = "Dockerfile"
-  tags = ["openspp:debian-bookworm-slim"]
+  tags = [
+    "${IMAGE_NAME}:debian-bookworm-slim-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:debian-bookworm-slim-${IMAGE_TAG}"
+  ]
   args = {
     BASE_IMAGE      = "debian:bookworm-slim"
-    OPENSPP_VERSION = "17.0.1-daily+odoo17.0-1"
+    
   }
   platforms = ["linux/amd64"]
 }
@@ -37,10 +63,12 @@ target "openspp-debian-trixie-slim" {
   inherits   = ["common"]
   context    = "."
   dockerfile = "Dockerfile"
-  tags = ["openspp:debian-trixie-slim"]
+  tags = [
+    "${IMAGE_NAME}:debian-trixie-slim-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:debian-trixie-slim-${IMAGE_TAG}"
+  ]
   args = {
     BASE_IMAGE      = "debian:trixie-slim"
-    OPENSPP_VERSION = "17.0.1-daily+odoo17.0-1"
   }
   platforms = ["linux/amd64"]
 }
@@ -49,10 +77,12 @@ target "openspp-ubuntu-24-04" {
   inherits   = ["common"]
   context    = "."
   dockerfile = "Dockerfile"
-  tags = ["openspp:ubuntu-24.04"]
+  tags = [
+    "${IMAGE_NAME}:ubuntu-24.04-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:ubuntu-24.04-${IMAGE_TAG}"
+  ]
   args = {
     BASE_IMAGE      = "ubuntu:24.04"
-    OPENSPP_VERSION = "17.0.1-daily+odoo17.0-1"
   }
   platforms = ["linux/amd64"]
 }
@@ -61,10 +91,12 @@ target "openspp-python-3-14-slim-bookworm" {
   inherits   = ["common"]
   context    = "."
   dockerfile = "Dockerfile"
-  tags = ["openspp:python-3-14-slim-bookworm"]
+  tags = [
+    "${IMAGE_NAME}:python-3-14-slim-bookworm-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:python-3-14-slim-bookworm-${IMAGE_TAG}"
+  ]
   args = {
     BASE_IMAGE      = "python:3.14-slim-bookworm"
-    OPENSPP_VERSION = "17.0.1-daily+odoo17.0-1"
   }
   platforms = ["linux/amd64"]
 }
@@ -73,10 +105,12 @@ target "openspp-python-3-13-slim-bookworm" {
   inherits   = ["common"]
   context    = "."
   dockerfile = "Dockerfile"
-  tags = ["openspp:python-3-13-slim-bookworm"]
+  tags = [
+    "${IMAGE_NAME}:python-3-13-slim-bookworm-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:python-3-13-slim-bookworm-${IMAGE_TAG}"
+  ]
   args = {
     BASE_IMAGE      = "python:3.13-slim-bookworm"
-    OPENSPP_VERSION = "17.0.1-daily+odoo17.0-1"
   }
   platforms = ["linux/amd64"]
 }
@@ -85,10 +119,12 @@ target "openspp-python-3-12-slim-bookworm" {
   inherits   = ["common"]
   context    = "."
   dockerfile = "Dockerfile"
-  tags = ["openspp:python-3-12-slim-bookworm"]
+  tags = [
+    "${IMAGE_NAME}:python-3-12-slim-bookworm-${IMAGE_TAG}",
+    "${PUSH_IMAGE_NAME}:python-3-12-slim-bookworm-${IMAGE_TAG}"
+  ]
   args = {
     BASE_IMAGE      = "python:3.12-slim-bookworm"
-    OPENSPP_VERSION = "17.0.1-daily+odoo17.0-1"
   }
   platforms = ["linux/amd64"]
 }


### PR DESCRIPTION
This pull request refactors the Docker build pipeline for OpenSPP, focusing on improved multi-stage builds, enhanced security, and more flexible image tagging and configuration. Both `Dockerfile` and `Dockerfile.slim` are restructured to streamline dependency installation, add support for multi-architecture, and simplify environment setup. The `docker-bake.hcl` file is updated to provide more dynamic and descriptive image tags, centralize build arguments, and enable easier registry management. These changes make the builds more maintainable, secure, and adaptable for different deployment targets.

**Dockerfile and Dockerfile.slim refactoring**

* Consolidated multi-stage builds: Now each Dockerfile has clear stages for installing OpenSPP, wkhtmltopdf, and final runtime setup, reducing duplication and improving readability. (`Dockerfile`, `Dockerfile.slim`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R85) [[2]](diffhunk://#diff-d8dcf21624927ddf769f7045c3f598ef432a45cd04a884591783a39a04cd6402L5-R83)
* Improved security and compatibility: Added explicit key verification for the OpenSPP APT repository and a fake `systemctl` to handle post-install scripts in containers. (`Dockerfile`, `Dockerfile.slim`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R85) [[2]](diffhunk://#diff-d8dcf21624927ddf769f7045c3f598ef432a45cd04a884591783a39a04cd6402L5-R83)
* Enhanced environment and user setup: Environment variables are set via `ENV`, and user/group creation uses configurable UID/GID for consistency and flexibility. (`Dockerfile`, `Dockerfile.slim`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L83-R145) [[2]](diffhunk://#diff-d8dcf21624927ddf769f7045c3f598ef432a45cd04a884591783a39a04cd6402L83-R135)
* Optimized dependency installation: Only essential runtime dependencies are installed, with conditional logic for language support and autopurging to minimize image size. (`Dockerfile`, `Dockerfile.slim`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L83-R145) [[2]](diffhunk://#diff-d8dcf21624927ddf769f7045c3f598ef432a45cd04a884591783a39a04cd6402L83-R135)
* Copying and permissions: Files and directories from build stages are copied with correct ownership and permissions, ensuring the container runs securely as a non-root user. (`Dockerfile`, `Dockerfile.slim`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R156-L167) [[2]](diffhunk://#diff-d8dcf21624927ddf769f7045c3f598ef432a45cd04a884591783a39a04cd6402R146-L151)

**docker-bake.hcl improvements**

* Centralized and dynamic build arguments: Registry, image name, tags, and other build parameters are now defined as variables, making builds more flexible and easier to maintain. [[1]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R1-R28) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R37-R57)
* Enhanced image tagging: Image tags now include registry, repository, base image, and tag details, supporting both internal and push registries for CI/CD workflows. [[1]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2R37-R57) [[2]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L40-L43) [[3]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L52-L55) [[4]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L64-L67) [[5]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L76-L79) [[6]](diffhunk://#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2L88-L91)
* Unified versioning and architecture: OpenSPP version, target architecture, and language support flags are set centrally and propagated to all build targets.
* Simplified build target management: Non-essential targets are commented out in the default group, making it easier to focus on primary builds.