### PR TITLE
fix: docker-entrypoint unset variables

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,28 +23,28 @@ log_error() {
 }
 
 # Support for Docker secrets via _FILE environment variables
-if [ -v PASSWORD_FILE ]; then
-  DB_PASSWORD="$(<"$PASSWORD_FILE")"
+if [ -n "${PASSWORD_FILE:-}" ] && [ -r "${PASSWORD_FILE}" ]; then
+  DB_PASSWORD="$(<"${PASSWORD_FILE}")"
 fi
 
-if [ -v DB_PASSWORD_FILE ]; then
-  DB_PASSWORD="$(<"$DB_PASSWORD_FILE")"
+if [ -n "${DB_PASSWORD_FILE:-}" ] && [ -r "${DB_PASSWORD_FILE}" ]; then
+  DB_PASSWORD="$(<"${DB_PASSWORD_FILE}")"
 fi
 
-if [ -v DB_USER_FILE ]; then
-  DB_USER="$(<"$DB_USER_FILE")"
+if [ -n "${DB_USER_FILE:-}" ] && [ -r "${DB_USER_FILE}" ]; then
+  DB_USER="$(<"${DB_USER_FILE}")"
 fi
 
-if [ -v DB_NAME_FILE ]; then
-  DB_NAME="$(<"$DB_NAME_FILE")"
+if [ -n "${DB_NAME_FILE:-}" ] && [ -r "${DB_NAME_FILE}" ]; then
+  DB_NAME="$(<"${DB_NAME_FILE}")"
 fi
 
-if [ -v ADMIN_PASSWORD_FILE ]; then
-  ODOO_ADMIN_PASSWORD="$(<"$ADMIN_PASSWORD_FILE")"
+if [ -n "${ADMIN_PASSWORD_FILE:-}" ] && [ -r "${ADMIN_PASSWORD_FILE}" ]; then
+  ODOO_ADMIN_PASSWORD="$(<"${ADMIN_PASSWORD_FILE}")"
 fi
 
-if [ -v ODOO_ADMIN_PASSWORD_FILE ]; then
-  ODOO_ADMIN_PASSWORD="$(<"$ODOO_ADMIN_PASSWORD_FILE")"
+if [ -n "${ODOO_ADMIN_PASSWORD_FILE:-}" ] && [ -r "${ODOO_ADMIN_PASSWORD_FILE}" ]; then
+  ODOO_ADMIN_PASSWORD="$(<"${ODOO_ADMIN_PASSWORD_FILE}")"
 fi
 
 # Set default database connection parameters
@@ -158,7 +158,7 @@ main() {
     fi
 
     # Database initialization (first run)
-    if [ -n "${INIT_DATABASE:-}" ] && [ "${INIT_DATABASE,,}" = "true" ]; then
+    if [ "${INIT_DATABASE,,}" = "true" ]; then
       log_info "Initializing database with base modules..."
 
       # Initialize with base module
@@ -195,7 +195,7 @@ main() {
     fi
 
     # Development mode
-    if [ -n "${ODOO_DEV_MODE:-}" ] && [ "${ODOO_DEV_MODE,,}" = "true" ]; then
+    if [ "${ODOO_DEV_MODE,,}" = "true" ]; then
       log_warn "Enabling development mode..."
       DB_ARGS+=("--dev=all")
       # Override workers for development

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -158,7 +158,7 @@ main() {
     fi
 
     # Database initialization (first run)
-    if [ "${INIT_DATABASE,,}" = "true" ]; then
+    if [ -n "${INIT_DATABASE:-}" ] && [ "${INIT_DATABASE,,}" = "true" ]; then
       log_info "Initializing database with base modules..."
 
       # Initialize with base module
@@ -179,7 +179,7 @@ main() {
     fi
 
     # Module installation
-    if [ -n "${INSTALL_MODULES}" ]; then
+    if [ -n "${INSTALL_MODULES:-}" ] && [ "${INSTALL_MODULES,,}" = "true" ]; then
       log_info "Installing modules: $INSTALL_MODULES"
       /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
         "${DB_ARGS[@]}" \
@@ -189,13 +189,13 @@ main() {
     fi
 
     # Module updates
-    if [ -n "${UPDATE_MODULES}" ]; then
+    if [ -n "${UPDATE_MODULES:-}" ] && [ "${UPDATE_MODULES,,}" = "true" ]; then
       log_info "Updating modules: $UPDATE_MODULES"
       DB_ARGS+=("--update=$UPDATE_MODULES")
     fi
 
     # Development mode
-    if [ "${ODOO_DEV_MODE,,}" = "true" ]; then
+    if [ -n "${ODOO_DEV_MODE:-}" ] && [ "${ODOO_DEV_MODE,,}" = "true" ]; then
       log_warn "Enabling development mode..."
       DB_ARGS+=("--dev=all")
       # Override workers for development

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,7 +28,7 @@ read_secret_from_file() {
     local var_to_set="$1" file_var_name="$2"
     local file_path="${!file_var_name:-}"
     if [ -n "$file_path" ] && [ -r "$file_path" ]; then
-        printf -v "$var_to_set" '%s' "$(<"$file_path")"
+        printf -v "$var_to_set" '%s' "$(tr -d '\n' < "$file_path")"
     fi
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -179,7 +179,7 @@ main() {
     fi
 
     # Module installation
-    if [ -n "${INSTALL_MODULES:-}" ] && [ "${INSTALL_MODULES,,}" = "true" ]; then
+    if [ -n "${INSTALL_MODULES:-}" ]; then
       log_info "Installing modules: $INSTALL_MODULES"
       /opt/openspp/venv/bin/python /opt/openspp/odoo-bin \
         "${DB_ARGS[@]}" \
@@ -189,7 +189,7 @@ main() {
     fi
 
     # Module updates
-    if [ -n "${UPDATE_MODULES:-}" ] && [ "${UPDATE_MODULES,,}" = "true" ]; then
+    if [ -n "${UPDATE_MODULES:-}" ]; then
       log_info "Updating modules: $UPDATE_MODULES"
       DB_ARGS+=("--update=$UPDATE_MODULES")
     fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,29 +23,21 @@ log_error() {
 }
 
 # Support for Docker secrets via _FILE environment variables
-if [ -n "${PASSWORD_FILE:-}" ] && [ -r "${PASSWORD_FILE}" ]; then
-  DB_PASSWORD="$(<"${PASSWORD_FILE}")"
-fi
+# Helper to read a secret from a file into a variable
+read_secret_from_file() {
+    local var_to_set=$1 file_var_name=$2
+    local file_path="${!file_var_name:-}"
+    if [ -n "$file_path" ] && [ -r "$file_path" ]; then
+        printf -v "$var_to_set" '%s' "$(<"$file_path")"
+    fi
+}
 
-if [ -n "${DB_PASSWORD_FILE:-}" ] && [ -r "${DB_PASSWORD_FILE}" ]; then
-  DB_PASSWORD="$(<"${DB_PASSWORD_FILE}")"
-fi
-
-if [ -n "${DB_USER_FILE:-}" ] && [ -r "${DB_USER_FILE}" ]; then
-  DB_USER="$(<"${DB_USER_FILE}")"
-fi
-
-if [ -n "${DB_NAME_FILE:-}" ] && [ -r "${DB_NAME_FILE}" ]; then
-  DB_NAME="$(<"${DB_NAME_FILE}")"
-fi
-
-if [ -n "${ADMIN_PASSWORD_FILE:-}" ] && [ -r "${ADMIN_PASSWORD_FILE}" ]; then
-  ODOO_ADMIN_PASSWORD="$(<"${ADMIN_PASSWORD_FILE}")"
-fi
-
-if [ -n "${ODOO_ADMIN_PASSWORD_FILE:-}" ] && [ -r "${ODOO_ADMIN_PASSWORD_FILE}" ]; then
-  ODOO_ADMIN_PASSWORD="$(<"${ODOO_ADMIN_PASSWORD_FILE}")"
-fi
+read_secret_from_file 'DB_PASSWORD' 'PASSWORD_FILE'
+read_secret_from_file 'DB_PASSWORD' 'DB_PASSWORD_FILE'
+read_secret_from_file 'DB_USER' 'DB_USER_FILE'
+read_secret_from_file 'DB_NAME' 'DB_NAME_FILE'
+read_secret_from_file 'ODOO_ADMIN_PASSWORD' 'ADMIN_PASSWORD_FILE'
+read_secret_from_file 'ODOO_ADMIN_PASSWORD' 'ODOO_ADMIN_PASSWORD_FILE'
 
 # Set default database connection parameters
 # Support both new-style and legacy environment variables for compatibility

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,7 +25,7 @@ log_error() {
 # Support for Docker secrets via _FILE environment variables
 # Helper to read a secret from a file into a variable
 read_secret_from_file() {
-    local var_to_set=$1 file_var_name=$2
+    local var_to_set="$1" file_var_name="$2"
     local file_path="${!file_var_name:-}"
     if [ -n "$file_path" ] && [ -r "$file_path" ]; then
         printf -v "$var_to_set" '%s' "$(<"$file_path")"


### PR DESCRIPTION
This fix hardens the docker-entrypoint.sh script, especially for unset variables.
If the variables are not set, we script will error since the variable is not set. This is intended to harden the script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden docker-entrypoint by safely handling unset variables and refactoring _FILE secret loading via a helper.
> 
> - **Entrypoint (`docker-entrypoint.sh`)**:
>   - **Secrets Handling**: Replace inline `_FILE` reads with `read_secret_from_file` helper; load `DB_PASSWORD`, `DB_USER`, `DB_NAME`, and `ODOO_ADMIN_PASSWORD` from corresponding `*_FILE` vars.
>   - **Unset-Variable Safety**: Guard conditionals and expansions with defaults (e.g., `${VAR:-}`) for `SKIP_DB_WAIT`, `INSTALL_MODULES`, `UPDATE_MODULES`, and positional `$1` in scaffold path.
>   - **Behavioral Tweaks**: No-op logic preserved; module install/update conditions now tolerant of missing envs; overall startup flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9918a2c048f0a429a2bc180b634dba63b6d13b6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->